### PR TITLE
BAU: Fix Jest errors in IDE

### DIFF
--- a/lambda/write-user-services/tsconfig.json
+++ b/lambda/write-user-services/tsconfig.json
@@ -9,7 +9,8 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "types": ["jest", "node"]
     },
-    "exclude": ["node_modules", "**/*.test.ts"]
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
VSCode couldn't find the Jest types, so was giving us errors in all the test files.

This commit adds Jest to the `tsconfig.json` and removes the test files from the exclude. This solves the IDE problems but means we're including the test files in the complied Javascript.

That's not ideal either, but we're a way off deploying these to production so we'll fix it later.

https://stackoverflow.com/questions/54139158/cannot-find-name-describe-do-you-need-to-install-type-definitions-for-a-test