### PR TITLE
GUA-426: Set up 'happy path' for writing to DynamoDB

### DIFF
--- a/lambda/write-user-services/index.ts
+++ b/lambda/write-user-services/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { UserServices } from "./models";
 
-const TABLE_NAME = "process.env.TABLE_NAME";
+const TABLE_NAME = process.env.TABLE_NAME;
 const marshallOptions = {
   convertClassInstanceToMap: true,
 };
@@ -18,6 +18,10 @@ const dynamoDocClient = DynamoDBDocumentClient.from(
   dynamoClient,
   translateConfig
 );
+
+export const validateUserServices = (userServices: UserServices): boolean => {
+  return true;
+};
 
 export const writeEvent = async (
   userServices: UserServices
@@ -36,6 +40,8 @@ export const writeEvent = async (
 export const lambdaHandler = async (event: SQSEvent): Promise<void> => {
   for (let i = 0; i < event.Records.length; i++) {
     const userServices: UserServices = JSON.parse(event.Records[i].body);
-    await writeEvent(userServices);
+    if (validateUserServices(userServices)) {
+      await writeEvent(userServices);
+    }
   }
 };

--- a/lambda/write-user-services/index.ts
+++ b/lambda/write-user-services/index.ts
@@ -23,7 +23,7 @@ export const validateUserServices = (userServices: UserServices): boolean => {
   return true;
 };
 
-export const writeEvent = async (
+export const writeUserServices = async (
   userServices: UserServices
 ): Promise<PutCommandOutput> => {
   const command = new PutCommand({
@@ -40,7 +40,7 @@ export const lambdaHandler = async (event: SQSEvent): Promise<void> => {
   for (let i = 0; i < event.Records.length; i++) {
     const userServices: UserServices = JSON.parse(event.Records[i].body);
     if (validateUserServices(userServices)) {
-      await writeEvent(userServices);
+      await writeUserServices(userServices);
     }
   }
 };

--- a/lambda/write-user-services/index.ts
+++ b/lambda/write-user-services/index.ts
@@ -33,7 +33,6 @@ export const writeEvent = async (
       services: userServices.services,
     },
   });
-  console.log(userServices);
   return await dynamoDocClient.send(command);
 };
 

--- a/lambda/write-user-services/index.ts
+++ b/lambda/write-user-services/index.ts
@@ -1,14 +1,41 @@
-import { SQSEvent, SQSRecord } from "aws-lambda";
-
+import { SQSEvent } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  PutCommandOutput,
+} from "@aws-sdk/lib-dynamodb";
 import { UserServices } from "./models";
 
-export const writeEvent = (userServices: UserServices): void => {
+const TABLE_NAME = "process.env.TABLE_NAME";
+const marshallOptions = {
+  convertClassInstanceToMap: true,
+};
+const translateConfig = { marshallOptions };
+
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(
+  dynamoClient,
+  translateConfig
+);
+
+export const writeEvent = async (
+  userServices: UserServices
+): Promise<PutCommandOutput> => {
+  const command = new PutCommand({
+    TableName: TABLE_NAME,
+    Item: {
+      user_id: userServices.user_id,
+      services: userServices.services,
+    },
+  });
   console.log(userServices);
+  return await dynamoDocClient.send(command);
 };
 
 export const lambdaHandler = async (event: SQSEvent): Promise<void> => {
   for (let i = 0; i < event.Records.length; i++) {
     const userServices: UserServices = JSON.parse(event.Records[i].body);
-    writeEvent(userServices);
+    await writeEvent(userServices);
   }
 };

--- a/lambda/write-user-services/index.ts
+++ b/lambda/write-user-services/index.ts
@@ -1,9 +1,14 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
 
-export const writeEvent = async (record: SQSRecord): Promise<void> => {
-  console.log(record.body);
+import { UserServices } from "./models";
+
+export const writeEvent = (userServices: UserServices): void => {
+  console.log(userServices);
 };
 
 export const lambdaHandler = async (event: SQSEvent): Promise<void> => {
-  event.Records.map((record) => writeEvent(record));
+  for (let i = 0; i < event.Records.length; i++) {
+    const userServices: UserServices = JSON.parse(event.Records[i].body);
+    writeEvent(userServices);
+  }
 };

--- a/lambda/write-user-services/models.ts
+++ b/lambda/write-user-services/models.ts
@@ -1,0 +1,13 @@
+type UrnFdnSub = String;
+type ClientId = String;
+
+export interface UserServices {
+  user_id: UrnFdnSub;
+  services: Service[];
+}
+
+export interface Service {
+  client_id: ClientId;
+  count_successful_logins: Number;
+  last_accessed: Date;
+}

--- a/lambda/write-user-services/package-lock.json
+++ b/lambda/write-user-services/package-lock.json
@@ -8,12 +8,17 @@
       "name": "write-user-services",
       "version": "1.0.0",
       "license": "OGL",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.186.0",
+        "@aws-sdk/lib-dynamodb": "^3.186.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.3",
         "@babel/preset-typescript": "^7.18.6",
         "@types/aws-lambda": "^8.10.106",
         "@types/jest": "^29.1.1",
+        "aws-sdk-client-mock": "^2.0.0",
         "babel-jest": "^29.1.2",
         "jest": "^29.1.2",
         "ts-jest": "^29.0.3",
@@ -32,6 +37,931 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-3Vq4UxqVUSRSIUbx83yfgiZezhOFYDG9ZazFjB4oDLIfqUSkH83IRCcJxJrANfw2xc3qdjzkBiQKyZu4Q9Xf4A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "@aws-sdk/util-waiter": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.186.0.tgz",
+      "integrity": "sha512-TF85iiU4tgpyiSVqmUPm4Wa1Cbu3LiRiLF9z87aL15w+VK+qvoiZEE7byDZKVm+L+9XziEk+W8PWp2mXin5udA==",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-914jSaxNMiPRK+vUHsx8EvVbogAovcc51Y2bvO2L91VmRiDgNMwUrtiY/2lDTYDgbnrblRntYufIrnk7XoGIIQ==",
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/smithy-client": "^3.0.0",
+        "@aws-sdk/types": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.186.0.tgz",
+      "integrity": "sha512-9smtYmke1TV2fbCIEOOfFojsKvhQYmv+W4KjYYn6yE7XgParT8AvcBE4pkWLOqoJvEEI/XhW1OlwMXOOlIuQRA==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/endpoint-cache": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-iY7O2PmH6PsnuZJzY5dDqV0caKs3Soz3o0N5TFkxyZlpiNU1M3ZNVPlsdKfCX7btpTUn+h1j/m35afXRCMQauA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.186.0.tgz",
+      "integrity": "sha512-oSm45VadBBWC/K2W1mrRNzm9RzbXt6VopBQ5iTDU7B3qIXlyAG9k1JqOvmYIdYq1oOgjM3Hv2+9sngi3+MZs1A==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2182,6 +3112,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2308,6 +3255,21 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -2415,6 +3377,17 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-2.0.0.tgz",
+      "integrity": "sha512-yjC39Ud78Cgwu9jLc7LoFILT8xtyvR9doCfd8tjeqaOI4oQ5IeTaIYDezWpWKndmrjXZzVLw/odWKP1hpuvsVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2561,6 +3534,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2918,6 +3896,14 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3020,6 +4006,18 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -3329,6 +4327,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4024,6 +5028,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4064,6 +5074,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.memoize": {
@@ -4154,6 +5170,14 @@
         "node": "*"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4165,6 +5189,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4225,6 +5262,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4351,6 +5393,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -4610,6 +5661,42 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -4927,6 +6014,11 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5025,6 +6117,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -5180,6 +6280,772 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-3Vq4UxqVUSRSIUbx83yfgiZezhOFYDG9ZazFjB4oDLIfqUSkH83IRCcJxJrANfw2xc3qdjzkBiQKyZu4Q9Xf4A==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "@aws-sdk/util-waiter": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/endpoint-cache": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.186.0.tgz",
+      "integrity": "sha512-TF85iiU4tgpyiSVqmUPm4Wa1Cbu3LiRiLF9z87aL15w+VK+qvoiZEE7byDZKVm+L+9XziEk+W8PWp2mXin5udA==",
+      "requires": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/lib-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-914jSaxNMiPRK+vUHsx8EvVbogAovcc51Y2bvO2L91VmRiDgNMwUrtiY/2lDTYDgbnrblRntYufIrnk7XoGIIQ==",
+      "requires": {
+        "@aws-sdk/util-dynamodb": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.186.0.tgz",
+      "integrity": "sha512-9smtYmke1TV2fbCIEOOfFojsKvhQYmv+W4KjYYn6yE7XgParT8AvcBE4pkWLOqoJvEEI/XhW1OlwMXOOlIuQRA==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/endpoint-cache": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-dynamodb": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.186.0.tgz",
+      "integrity": "sha512-iY7O2PmH6PsnuZJzY5dDqV0caKs3Soz3o0N5TFkxyZlpiNU1M3ZNVPlsdKfCX7btpTUn+h1j/m35afXRCMQauA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.186.0.tgz",
+      "integrity": "sha512-oSm45VadBBWC/K2W1mrRNzm9RzbXt6VopBQ5iTDU7B3qIXlyAG9k1JqOvmYIdYq1oOgjM3Hv2+9sngi3+MZs1A==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -6728,6 +8594,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -6854,6 +8737,21 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -6934,6 +8832,17 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aws-sdk-client-mock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-2.0.0.tgz",
+      "integrity": "sha512-yjC39Ud78Cgwu9jLc7LoFILT8xtyvR9doCfd8tjeqaOI4oQ5IeTaIYDezWpWKndmrjXZzVLw/odWKP1hpuvsVQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinon": "^10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
       }
     },
     "babel-jest": {
@@ -7050,6 +8959,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7308,6 +9222,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -7382,6 +9301,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fb-watchman": {
       "version": "2.0.2",
@@ -7602,6 +9526,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "isexe": {
@@ -8135,6 +10065,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -8166,6 +10102,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.memoize": {
@@ -8238,6 +10180,14 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "requires": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8249,6 +10199,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -8294,6 +10257,11 @@
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
+    },
+    "obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "once": {
       "version": "1.4.0",
@@ -8383,6 +10351,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "picocolors": {
       "version": "1.0.0",
@@ -8583,6 +10560,37 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        }
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -8790,6 +10798,11 @@
         "yn": "3.1.1"
       }
     },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -8845,6 +10858,11 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/lambda/write-user-services/package.json
+++ b/lambda/write-user-services/package.json
@@ -18,10 +18,15 @@
     "@babel/preset-typescript": "^7.18.6",
     "@types/aws-lambda": "^8.10.106",
     "@types/jest": "^29.1.1",
+    "aws-sdk-client-mock": "^2.0.0",
     "babel-jest": "^29.1.2",
     "jest": "^29.1.2",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.186.0",
+    "@aws-sdk/lib-dynamodb": "^3.186.0"
   }
 }

--- a/lambda/write-user-services/tests/index.test.ts
+++ b/lambda/write-user-services/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { lambdaHandler, writeEvent } from "../index";
+import { lambdaHandler, writeEvent, validateUserServices } from "../index";
 import { UserServices } from "../models";
 
 import { mockClient } from "aws-sdk-client-mock";
@@ -61,6 +61,12 @@ describe("writeEvent", () => {
   test("writes to DynamoDB", async () => {
     await writeEvent(TEST_USER_SERVICES);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+  });
+});
+
+describe("validateUserServices", () => {
+  test("returns true", () => {
+    expect(validateUserServices(TEST_USER_SERVICES)).toEqual(true);
   });
 });
 

--- a/lambda/write-user-services/tests/index.test.ts
+++ b/lambda/write-user-services/tests/index.test.ts
@@ -37,25 +37,17 @@ const TEST_SQS_EVENT: SQSEvent = {
   Records: [TEST_SQS_RECORD, TEST_SQS_RECORD],
 };
 
-let consoleMock: jest.SpyInstance;
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
 describe("writeEvent", () => {
   beforeEach(() => {
-    consoleMock = jest.spyOn(global.console, "log");
     dynamoMock.reset();
 
     process.env.TABLE_NAME = "TABLE_NAME";
   });
 
   afterEach(() => {
-    consoleMock.mockRestore();
     jest.clearAllMocks();
-  });
-
-  test("logs to the console", async () => {
-    await writeEvent(TEST_USER_SERVICES);
-    expect(consoleMock).toHaveBeenCalledTimes(1);
   });
 
   test("writes to DynamoDB", async () => {
@@ -72,20 +64,17 @@ describe("validateUserServices", () => {
 
 describe("lambdaHandler", () => {
   beforeEach(() => {
-    consoleMock = jest.spyOn(global.console, "log");
     dynamoMock.reset();
 
     process.env.TABLE_NAME = "TABLE_NAME";
   });
 
   afterEach(() => {
-    consoleMock.mockRestore();
     jest.clearAllMocks();
   });
 
   test("it iterates over each record in the batch", async () => {
     await lambdaHandler(TEST_SQS_EVENT);
-    expect(consoleMock).toHaveBeenCalledTimes(2);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(2);
   });
 });

--- a/lambda/write-user-services/tests/index.test.ts
+++ b/lambda/write-user-services/tests/index.test.ts
@@ -1,5 +1,9 @@
-import { writeEvent } from "../index";
+import { lambdaHandler, writeEvent } from "../index";
 import { UserServices } from "../models";
+
+import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { SQSEvent, SQSRecord } from "aws-lambda";
 
 const TEST_USER_SERVICES: UserServices = {
   user_id: "user-id",
@@ -12,9 +16,70 @@ const TEST_USER_SERVICES: UserServices = {
   ],
 };
 
-test("it logs to the console", () => {
-  const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
-  writeEvent(TEST_USER_SERVICES);
-  expect(consoleLogMock).toHaveBeenCalledTimes(1);
-  consoleLogMock.mockRestore();
+const TEST_SQS_RECORD: SQSRecord = {
+  messageId: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+  receiptHandle: "MessageReceiptHandle",
+  body: JSON.stringify(TEST_USER_SERVICES),
+  attributes: {
+    ApproximateReceiveCount: "1",
+    SentTimestamp: "1523232000000",
+    SenderId: "123456789012",
+    ApproximateFirstReceiveTimestamp: "1523232000001",
+  },
+  messageAttributes: {},
+  md5OfBody: "7b270e59b47ff90a553787216d55d91d",
+  eventSource: "aws:sqs",
+  eventSourceARN: "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+  awsRegion: "us-east-1",
+};
+
+const TEST_SQS_EVENT: SQSEvent = {
+  Records: [TEST_SQS_RECORD, TEST_SQS_RECORD],
+};
+
+let consoleMock: jest.SpyInstance;
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+describe("writeEvent", () => {
+  beforeEach(() => {
+    consoleMock = jest.spyOn(global.console, "log");
+    dynamoMock.reset();
+
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    consoleMock.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  test("logs to the console", async () => {
+    await writeEvent(TEST_USER_SERVICES);
+    expect(consoleMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("writes to DynamoDB", async () => {
+    await writeEvent(TEST_USER_SERVICES);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+  });
+});
+
+describe("lambdaHandler", () => {
+  beforeEach(() => {
+    consoleMock = jest.spyOn(global.console, "log");
+    dynamoMock.reset();
+
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    consoleMock.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  test("it iterates over each record in the batch", async () => {
+    await lambdaHandler(TEST_SQS_EVENT);
+    expect(consoleMock).toHaveBeenCalledTimes(2);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(2);
+  });
 });

--- a/lambda/write-user-services/tests/index.test.ts
+++ b/lambda/write-user-services/tests/index.test.ts
@@ -1,26 +1,20 @@
 import { writeEvent } from "../index";
-import { SQSRecord } from "aws-lambda";
+import { UserServices } from "../models";
 
-const TEST_RECORD: SQSRecord = {
-  messageId: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
-  receiptHandle: "MessageReceiptHandle",
-  body: "Hello from SQS!",
-  attributes: {
-    ApproximateReceiveCount: "1",
-    SentTimestamp: "1523232000000",
-    SenderId: "123456789012",
-    ApproximateFirstReceiveTimestamp: "1523232000001",
-  },
-  messageAttributes: {},
-  md5OfBody: "7b270e59b47ff90a553787216d55d91d",
-  eventSource: "aws:sqs",
-  eventSourceARN: "arn:aws:sqs:us-east-1:123456789012:MyQueue",
-  awsRegion: "us-east-1",
+const TEST_USER_SERVICES: UserServices = {
+  user_id: "user-id",
+  services: [
+    {
+      client_id: "client_id",
+      last_accessed: new Date(),
+      count_successful_logins: 1,
+    },
+  ],
 };
 
-test("it logs to the console", async () => {
+test("it logs to the console", () => {
   const consoleLogMock = jest.spyOn(console, "log").mockImplementation();
-  await writeEvent(TEST_RECORD);
+  writeEvent(TEST_USER_SERVICES);
   expect(consoleLogMock).toHaveBeenCalledTimes(1);
   consoleLogMock.mockRestore();
 });

--- a/lambda/write-user-services/tests/index.test.ts
+++ b/lambda/write-user-services/tests/index.test.ts
@@ -1,4 +1,8 @@
-import { lambdaHandler, writeEvent, validateUserServices } from "../index";
+import {
+  lambdaHandler,
+  writeUserServices,
+  validateUserServices,
+} from "../index";
 import { UserServices } from "../models";
 
 import { mockClient } from "aws-sdk-client-mock";
@@ -39,7 +43,7 @@ const TEST_SQS_EVENT: SQSEvent = {
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
-describe("writeEvent", () => {
+describe("writeUserServices", () => {
   beforeEach(() => {
     dynamoMock.reset();
 
@@ -51,7 +55,7 @@ describe("writeEvent", () => {
   });
 
   test("writes to DynamoDB", async () => {
-    await writeEvent(TEST_USER_SERVICES);
+    await writeUserServices(TEST_USER_SERVICES);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
   });
 });


### PR DESCRIPTION
This PR sets up the 'happy path' for the lambda function to write events to DynamoDB. There's a function and test to do data structure validation, but it always returns `true` at the moment. I'll tackle that, error handling and logging in my next PRs.  

I've used the interfaces Huw wrote for the data structures. They're good, but I'm not completely sure about the file structure I've gone with here. I'm also pretty confident that this will work when deployed thanks to the type system, but there might need to be some tweaks when we get to that step, since I can't test deploying it at the moment. 