### PR TITLE
GUA-426: Send events that cause an error to the DLQ

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -79,8 +79,8 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_ARN: !GetAtt QueryUserServicesDeadLetterQueue.Arn
-          OUTPUT_QUEUE_ARN: !GetAtt UserServicesToFormatQueue.Arn
+          DLQ_URL: !Ref QueryUserServicesDeadLetterQueue
+          OUTPUT_QUEUE_URL: !Ref UserServicesToFormatQueue
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -169,8 +169,8 @@ Resources:
       Timeout: 5
       Environment:
         Variables:
-          DLQ_ARN: !GetAtt FormatUserServicesDeadLetterQueue.Arn
-          OUTPUT_QUEUE_ARN: !GetAtt UserServicesToWriteQueue.Arn
+          DLQ_URL: !Ref FormatUserServicesDeadLetterQueue
+          OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -251,7 +251,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_ARN: !GetAtt WriteServicesDeadLetterQueue.Arn
+          DLQ_URL: !Ref WriteServicesDeadLetterQueue
     Metadata:
       BuildMethod: esbuild
       BuildProperties:

--- a/lambda/write-user-services/package-lock.json
+++ b/lambda/write-user-services/package-lock.json
@@ -10,13 +10,14 @@
       "license": "OGL",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.186.0",
-        "@aws-sdk/lib-dynamodb": "^3.186.0"
+        "@aws-sdk/client-sqs": "^3.186.0",
+        "@aws-sdk/lib-dynamodb": "^3.186.0",
+        "@types/aws-lambda": "^8.10.106"
       },
       "devDependencies": {
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.3",
         "@babel/preset-typescript": "^7.18.6",
-        "@types/aws-lambda": "^8.10.106",
         "@types/jest": "^29.1.1",
         "@typescript-eslint/eslint-plugin": "^5.40.0",
         "aws-sdk-client-mock": "^2.0.0",
@@ -178,6 +179,54 @@
         "@aws-sdk/util-waiter": "3.186.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.186.0.tgz",
+      "integrity": "sha512-QetQrUek5soxMSdP7HADxsO/l4OLNI20s4lPGsPk+imp0kXd+SIxOz4qHh6vmxEMkjdUq7eA5RRRndN6M2pYzg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/md5-js": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -467,6 +516,17 @@
         "@aws-sdk/types": "^3.0.0"
       }
     },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.186.0.tgz",
+      "integrity": "sha512-Pp86oeTi8qtfY4fIZYrHOqRWJc0PjolxETdtWBUhtjC8HY81ckZMqe+5Aosy8mtQJus/k83S0CJAyfE2ko/a6Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
@@ -544,6 +604,19 @@
         "@aws-sdk/util-middleware": "3.186.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.186.0.tgz",
+      "integrity": "sha512-UZp6PkIJnVGa7/vEAKQx+ria0599E+OuHjFATzRBrOMVXRQ6nG/dOVIlGwHrM2xEZf96CoK8j6RNwcioyUhf5Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3334,8 +3407,7 @@
     "node_modules/@types/aws-lambda": {
       "version": "8.10.106",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.106.tgz",
-      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ==",
-      "dev": true
+      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -8891,6 +8963,51 @@
         "uuid": "^8.3.2"
       }
     },
+    "@aws-sdk/client-sqs": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.186.0.tgz",
+      "integrity": "sha512-QetQrUek5soxMSdP7HADxsO/l4OLNI20s4lPGsPk+imp0kXd+SIxOz4qHh6vmxEMkjdUq7eA5RRRndN6M2pYzg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/md5-js": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/client-sso": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
@@ -9128,6 +9245,17 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.186.0.tgz",
+      "integrity": "sha512-Pp86oeTi8qtfY4fIZYrHOqRWJc0PjolxETdtWBUhtjC8HY81ckZMqe+5Aosy8mtQJus/k83S0CJAyfE2ko/a6Q==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
@@ -9190,6 +9318,16 @@
         "@aws-sdk/util-middleware": "3.186.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.186.0.tgz",
+      "integrity": "sha512-UZp6PkIJnVGa7/vEAKQx+ria0599E+OuHjFATzRBrOMVXRQ6nG/dOVIlGwHrM2xEZf96CoK8j6RNwcioyUhf5Q==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -11230,8 +11368,7 @@
     "@types/aws-lambda": {
       "version": "8.10.106",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.106.tgz",
-      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ==",
-      "dev": true
+      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ=="
     },
     "@types/babel__core": {
       "version": "7.1.19",

--- a/lambda/write-user-services/package.json
+++ b/lambda/write-user-services/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.186.0",
+    "@aws-sdk/client-sqs": "^3.186.0",
     "@aws-sdk/lib-dynamodb": "^3.186.0",
     "@types/aws-lambda": "^8.10.106"
   }


### PR DESCRIPTION
Update the Cloudformation to pass the SQS queue URLs through as environment variables, not ARNs, since the SQS SDK needs the URL. 

Then add logic to the handler which puts any event which caused an error onto the dead letter queue without modifying or trying to parse it.