### PR TITLE
GUA-436: Set up CI for Cloudformation and `write-user-services` lambda

### DIFF
--- a/.github/workflows/lint-and-test-lambdas.yaml
+++ b/.github/workflows/lint-and-test-lambdas.yaml
@@ -1,0 +1,21 @@
+name: Lint and test lambdas
+
+on: pull_request
+
+jobs:
+  lint_and_test_write_user_services:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./lambda/write-user-services
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install write-user-services dependencies
+        run: npm ci
+
+      - name: Lint write-user-services
+        run: npm run lint
+
+      - name: Test write-user-services
+        run: npm test

--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -1,0 +1,22 @@
+name: CloudFormation Linter
+
+on: pull_request
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Install cfn-lint
+        run: python -m pip install cfn-lint
+
+      - name: Run linter
+        run: cfn-lint infrastructure/template.yaml


### PR DESCRIPTION
These will run when a pull request is opened and run linting and the unit tests for each lambda, plus lint the Cloudformation template.

To add the other lambdas we'll just need to copy the whole job and change the `working_directory` value for each.

It's possible that the lambda action ends up taking a long time to run, particularly if we end up with a lot of lambdas in this repo, or if some of those lambdas have a lot of dependencies.

If that happens we can look at splitting this action up or caching dependencies [1], but I don't think we need to do that right away.

[1]:https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows