### PR TITLE
GUA-436: Skip infra tests when unchanged

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -1,10 +1,13 @@
 name: CloudFormation Linter
 
-on: pull_request
+on: 
+  pull_request: 
+    paths:
+      - 'infrastructure/**'
 
 jobs:
-  lint:
-    name: lint
+  lint_cloudformation:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/skip-lint-cloudformation.yaml
+++ b/.github/workflows/skip-lint-cloudformation.yaml
@@ -1,0 +1,13 @@
+name: CloudFormation Linter
+
+on: 
+  pull_request: 
+    paths-ingnore:
+      - 'infrastructure/**'
+
+jobs:
+  lint_cloudformation:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes to Cloudformation files - skipping checks"'


### PR DESCRIPTION
Use the `paths` filter [[1]] to skip the Cloudformation lint check if no files have changed in the `infrastructure/` folder.

In order to have this check as a 'required check' before a PR can be merged, we also need to add a second action, with a job of the same name that *only* runs when no files have changed in the `infrastructure/`folder [[2]].

There are still two passing checks on this PR, but the logs for Cloudformation linter one show that it's run the new action and not any checks (as expected, since this PR doesn't change any infrastructure code).

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
[2]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks