### PR TITLE
BAU: Move @aws-sdk/client-sqs out of devDependencies

### DIFF
--- a/lambda/format-user-services/package-lock.json
+++ b/lambda/format-user-services/package-lock.json
@@ -13,7 +13,6 @@
         "@types/aws-lambda": "^8.10.106"
       },
       "devDependencies": {
-        "@aws-sdk/client-sqs": "^3.186.0",
         "@babel/core": "^7.19.3",
         "@babel/preset-env": "^7.19.3",
         "@babel/preset-typescript": "^7.18.6",
@@ -55,7 +54,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -63,14 +61,12 @@
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -85,14 +81,12 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -102,14 +96,12 @@
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -117,14 +109,12 @@
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -134,14 +124,12 @@
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
       "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -154,7 +142,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.186.0.tgz",
       "integrity": "sha512-QetQrUek5soxMSdP7HADxsO/l4OLNI20s4lPGsPk+imp0kXd+SIxOz4qHh6vmxEMkjdUq7eA5RRRndN6M2pYzg==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -203,7 +190,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
       "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -245,7 +231,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
       "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -292,7 +277,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
       "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -308,7 +292,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
       "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -322,7 +305,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
       "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -338,7 +320,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
       "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -357,7 +338,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
       "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -378,7 +358,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
       "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/shared-ini-file-loader": "3.186.0",
@@ -393,7 +372,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
       "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -409,7 +387,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
       "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -423,7 +400,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
       "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/querystring-builder": "3.186.0",
@@ -436,7 +412,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
       "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-buffer-from": "3.186.0",
@@ -450,7 +425,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
       "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -460,7 +434,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
       "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -472,7 +445,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.186.0.tgz",
       "integrity": "sha512-Pp86oeTi8qtfY4fIZYrHOqRWJc0PjolxETdtWBUhtjC8HY81ckZMqe+5Aosy8mtQJus/k83S0CJAyfE2ko/a6Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-utf8-browser": "3.186.0",
@@ -484,7 +456,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
       "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -498,7 +469,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
       "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -512,7 +482,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
       "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -525,7 +494,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
       "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -539,7 +507,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
       "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/service-error-classification": "3.186.0",
@@ -556,7 +523,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.186.0.tgz",
       "integrity": "sha512-UZp6PkIJnVGa7/vEAKQx+ria0599E+OuHjFATzRBrOMVXRQ6nG/dOVIlGwHrM2xEZf96CoK8j6RNwcioyUhf5Q==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-hex-encoding": "3.186.0",
@@ -570,7 +536,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
       "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -587,7 +552,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
       "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -600,7 +564,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
       "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/protocol-http": "3.186.0",
@@ -617,7 +580,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
       "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -629,7 +591,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
       "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -643,7 +604,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
       "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/shared-ini-file-loader": "3.186.0",
@@ -658,7 +618,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
       "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.186.0",
         "@aws-sdk/protocol-http": "3.186.0",
@@ -674,7 +633,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
       "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -687,7 +645,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
       "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -700,7 +657,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
       "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-uri-escape": "3.186.0",
@@ -714,7 +670,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
       "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -727,7 +682,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
       "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
-      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -736,7 +690,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
       "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -749,7 +702,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
       "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -766,7 +718,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
       "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -780,7 +731,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
       "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -789,7 +739,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
       "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -800,7 +749,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
       "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -809,7 +757,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
       "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.186.0",
         "tslib": "^2.3.1"
@@ -822,7 +769,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
       "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -831,7 +777,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
       "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -843,7 +788,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
       "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.186.0",
         "tslib": "^2.3.1"
@@ -856,7 +800,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
       "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -868,7 +811,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
       "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -883,7 +825,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
       "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -900,7 +841,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
       "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -912,7 +852,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
       "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -924,7 +863,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
       "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -936,7 +874,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
       "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -948,7 +885,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
       "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.186.0",
         "bowser": "^2.11.0",
@@ -959,7 +895,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
       "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -981,7 +916,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
       "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -990,7 +924,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
       "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-      "dev": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.186.0",
         "tslib": "^2.3.1"
@@ -4836,8 +4769,7 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -5280,7 +5212,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -6281,7 +6212,6 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-      "dev": true,
       "bin": {
         "xml2js": "cli.js"
       },
@@ -10401,8 +10331,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10595,7 +10524,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10856,7 +10784,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -10864,8 +10791,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -10873,7 +10799,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -10888,8 +10813,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -10897,7 +10821,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "dev": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -10907,8 +10830,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -10916,7 +10838,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -10924,8 +10845,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -10933,7 +10853,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -10943,8 +10862,7 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -10952,7 +10870,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
       "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -10962,7 +10879,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.186.0.tgz",
       "integrity": "sha512-QetQrUek5soxMSdP7HADxsO/l4OLNI20s4lPGsPk+imp0kXd+SIxOz4qHh6vmxEMkjdUq7eA5RRRndN6M2pYzg==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -11008,7 +10924,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
       "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -11047,7 +10962,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
       "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
-      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -11091,7 +11005,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
       "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11104,7 +11017,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
       "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11115,7 +11027,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
       "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -11128,7 +11039,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
       "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -11144,7 +11054,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
       "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -11162,7 +11071,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
       "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/shared-ini-file-loader": "3.186.0",
@@ -11174,7 +11082,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
       "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/client-sso": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -11187,7 +11094,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
       "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11198,7 +11104,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
       "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/querystring-builder": "3.186.0",
@@ -11211,7 +11116,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
       "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-buffer-from": "3.186.0",
@@ -11222,7 +11126,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
       "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11232,7 +11135,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
       "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11241,7 +11143,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.186.0.tgz",
       "integrity": "sha512-Pp86oeTi8qtfY4fIZYrHOqRWJc0PjolxETdtWBUhtjC8HY81ckZMqe+5Aosy8mtQJus/k83S0CJAyfE2ko/a6Q==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-utf8-browser": "3.186.0",
@@ -11253,7 +11154,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
       "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11264,7 +11164,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
       "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11275,7 +11174,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
       "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11285,7 +11183,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
       "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11296,7 +11193,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
       "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/service-error-classification": "3.186.0",
@@ -11310,7 +11206,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.186.0.tgz",
       "integrity": "sha512-UZp6PkIJnVGa7/vEAKQx+ria0599E+OuHjFATzRBrOMVXRQ6nG/dOVIlGwHrM2xEZf96CoK8j6RNwcioyUhf5Q==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-hex-encoding": "3.186.0",
@@ -11321,7 +11216,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
       "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.186.0",
         "@aws-sdk/property-provider": "3.186.0",
@@ -11335,7 +11229,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
       "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11345,7 +11238,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
       "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/protocol-http": "3.186.0",
@@ -11359,7 +11251,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
       "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11368,7 +11259,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
       "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11379,7 +11269,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
       "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/shared-ini-file-loader": "3.186.0",
@@ -11391,7 +11280,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
       "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.186.0",
         "@aws-sdk/protocol-http": "3.186.0",
@@ -11404,7 +11292,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
       "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11414,7 +11301,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
       "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11424,7 +11310,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
       "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "@aws-sdk/util-uri-escape": "3.186.0",
@@ -11435,7 +11320,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
       "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11444,14 +11328,12 @@
     "@aws-sdk/service-error-classification": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
-      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
-      "dev": true
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
       "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "tslib": "^2.3.1"
@@ -11461,7 +11343,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
       "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
-      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11475,7 +11356,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
       "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11485,14 +11365,12 @@
     "@aws-sdk/types": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
-      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
-      "dev": true
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
     },
     "@aws-sdk/url-parser": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
       "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11503,7 +11381,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
       "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11512,7 +11389,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
       "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.186.0",
         "tslib": "^2.3.1"
@@ -11522,7 +11398,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
       "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11531,7 +11406,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
       "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11540,7 +11414,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
       "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.186.0",
         "tslib": "^2.3.1"
@@ -11550,7 +11423,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
       "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11559,7 +11431,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
       "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11571,7 +11442,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
       "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
-      "dev": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.186.0",
         "@aws-sdk/credential-provider-imds": "3.186.0",
@@ -11585,7 +11455,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
       "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11594,7 +11463,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
       "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11603,7 +11471,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
       "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11612,7 +11479,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
       "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11621,7 +11487,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
       "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
-      "dev": true,
       "requires": {
         "@aws-sdk/types": "3.186.0",
         "bowser": "^2.11.0",
@@ -11632,7 +11497,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
       "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
-      "dev": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.186.0",
         "@aws-sdk/types": "3.186.0",
@@ -11643,7 +11507,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
       "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -11652,7 +11515,6 @@
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
       "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
-      "dev": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.186.0",
         "tslib": "^2.3.1"
@@ -14463,8 +14325,7 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -14796,8 +14657,7 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -15526,8 +15386,7 @@
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
-      "dev": true
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -18541,8 +18400,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -18682,8 +18540,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/lambda/format-user-services/package.json
+++ b/lambda/format-user-services/package.json
@@ -10,7 +10,6 @@
   "author": "GDS",
   "license": "OGL",
   "devDependencies": {
-    "@aws-sdk/client-sqs": "^3.186.0",
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.3",
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
This was the case in format-user-services lambda, somehow it had made it into both and that fact was causing `sam build` to fail