### PR TITLE
GUA-448: Allow lambdas to write logs to Cloudwatch

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -98,6 +98,8 @@ Resources:
   QueryUserServicesRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -188,6 +190,8 @@ Resources:
   FormatUserServicesRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -269,6 +273,8 @@ Resources:
   WriteServiceRecordRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
In order to debug the system, we need to see the lambda logs and metrics. Give the built in [`AWSLambdaBasicExecutionRole`](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole) permissions to each of the new lambda functions, which is the [AWS recommended way](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html#permissions-executionrole-features) to grant these permissions.