### PR TITLE
GUA-448: Get the happy path working for lambda functions

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -246,7 +246,7 @@ Resources:
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt WriteServicesDeadLetterQueue.Arn
-      Handler: store-service-record.handler
+      Handler: write-user-services.handler
       PackageType: Zip
       MemorySize: 128
       Runtime: nodejs16.x

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -100,6 +100,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Ref QueryUserServicesPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -113,8 +114,6 @@ Resources:
   QueryUserServicesPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Roles:
-        - !Ref QueryUserServicesRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -192,6 +191,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Ref FormatUserServicesPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -205,8 +205,6 @@ Resources:
   FormatUserServicesPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Roles:
-        - !Ref FormatUserServicesRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -275,6 +273,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Ref WriteServiceRecordPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -288,8 +287,6 @@ Resources:
   WriteServiceRecordPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      Roles:
-        - !Ref WriteServiceRecordRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -98,6 +98,8 @@ Resources:
   QueryUserServicesRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -188,6 +190,8 @@ Resources:
   FormatUserServicesRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -269,6 +273,8 @@ Resources:
   WriteServiceRecordRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -127,12 +127,12 @@ export const sendSqsMessage = async (
 };
 
 export const handler = async (event: SQSEvent): Promise<void> => {
-  const { QUEUE_URL } = process.env;
+  const { OUTPUT_QUEUE_URL } = process.env;
   const { Records } = event;
 
   Records.forEach(async (record) => {
     const formattedRecord = formatRecord(validateAndParseSQSRecord(record));
-    const messageId = await sendSqsMessage(formattedRecord, QUEUE_URL);
+    const messageId = await sendSqsMessage(formattedRecord, OUTPUT_QUEUE_URL);
     console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
   });
 };

--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -9,7 +9,7 @@ import type {
   UserRecordEvent,
   UserServices,
   Service,
-  TxmaEventBody,
+  TxmaEvent,
 } from "./models";
 
 const { AWS_REGION } = process.env;
@@ -47,7 +47,7 @@ const validateUser = (user: UserData): void => {
   }
 };
 
-const validateTxmaEventBody = (txmaEvent: TxmaEventBody): void => {
+const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
@@ -65,16 +65,16 @@ export const validateAndParseSQSRecord = (
   record: SQSRecord
 ): UserRecordEvent => {
   const parsedRecord = JSON.parse(record.body);
-  const { TxmaEventBody, ServiceList } = parsedRecord;
-  validateTxmaEventBody(TxmaEventBody);
+  const { TxmaEvent, ServiceList } = parsedRecord;
+  validateTxmaEvent(TxmaEvent);
   validateUserServices(ServiceList);
   return parsedRecord;
 };
 
-export const newServicePresenter = (txmaEventBody: TxmaEventBody): Service => ({
-  client_id: txmaEventBody.client_id,
+export const newServicePresenter = (TxmaEvent: TxmaEvent): Service => ({
+  client_id: TxmaEvent.client_id,
   count_successful_logins: 1,
-  last_accessed: txmaEventBody.timestamp,
+  last_accessed: TxmaEvent.timestamp,
 });
 
 export const existingServicePresenter = (
@@ -88,26 +88,26 @@ export const existingServicePresenter = (
 
 export const conditionallyUpsertServiceList = (
   matchingService: Service | undefined,
-  TxmaEventBody: TxmaEventBody
+  TxmaEvent: TxmaEvent
 ): Service => ({
   ...(!matchingService
-    ? newServicePresenter(TxmaEventBody)
-    : existingServicePresenter(matchingService, TxmaEventBody.timestamp)),
+    ? newServicePresenter(TxmaEvent)
+    : existingServicePresenter(matchingService, TxmaEvent.timestamp)),
 });
 
 export const formatRecord = (record: UserRecordEvent) => {
-  const { TxmaEventBody, ServiceList } = record;
+  const { TxmaEvent, ServiceList } = record;
   const matchingRecord = ServiceList.find(
-    (service) => TxmaEventBody.client_id === service.client_id
+    (service) => TxmaEvent.client_id === service.client_id
   );
   const nonMatchingRecords = ServiceList.filter(
-    (service) => TxmaEventBody.client_id !== service.client_id
+    (service) => TxmaEvent.client_id !== service.client_id
   );
 
   return {
-    user_id: TxmaEventBody.user.user_id,
+    user_id: TxmaEvent.user.user_id,
     services: [
-      ...[conditionallyUpsertServiceList(matchingRecord, TxmaEventBody)],
+      ...[conditionallyUpsertServiceList(matchingRecord, TxmaEvent)],
       ...nonMatchingRecords,
     ],
   };
@@ -130,9 +130,11 @@ export const handler = async (event: SQSEvent): Promise<void> => {
   const { OUTPUT_QUEUE_URL } = process.env;
   const { Records } = event;
 
-  Records.forEach(async (record) => {
-    const formattedRecord = formatRecord(validateAndParseSQSRecord(record));
-    const messageId = await sendSqsMessage(formattedRecord, OUTPUT_QUEUE_URL);
-    console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
-  });
+  await Promise.all(
+    Records.map(async (record) => {
+      const formattedRecord = formatRecord(validateAndParseSQSRecord(record));
+      const messageId = await sendSqsMessage(formattedRecord, OUTPUT_QUEUE_URL);
+      console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
+    })
+  );
 };

--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -2,7 +2,7 @@ type UrnFdnSub = string;
 type ClientId = string;
 
 export interface UserRecordEvent {
-  TxmaEventBody: TxmaEventBody;
+  TxmaEvent: TxmaEvent;
   ServiceList: Service[];
 }
 
@@ -12,7 +12,7 @@ export interface Service {
   last_accessed: string;
 }
 
-export interface TxmaEventBody {
+export interface TxmaEvent {
   event_name: string;
   timestamp: string;
   client_id: ClientId;

--- a/lambda/format-user-services/tests/testHelpers.ts
+++ b/lambda/format-user-services/tests/testHelpers.ts
@@ -4,7 +4,7 @@ import type {
   Service,
   UserRecordEvent,
   UserServices,
-  TxmaEventBody,
+  TxmaEvent,
 } from "../models";
 
 export const makeServiceRecord = (
@@ -36,10 +36,7 @@ export const makeSQSEventFixture = (
   awsRegion: "us-east-1",
 });
 
-export const makeTxmaEventBody = (
-  clientId: string,
-  userId: string
-): TxmaEventBody => ({
+export const makeTxmaEvent = (clientId: string, userId: string): TxmaEvent => ({
   event_name: "event_1",
   timestamp: "2022-01-01T12:00:00.000Z",
   client_id: clientId,

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -25,7 +25,7 @@ export const queryUserServices = async (userId: string): Promise<Service[]> => {
   const command = new GetCommand({
     TableName: TABLE_NAME,
     Key: {
-      userId,
+      user_id: userId,
     },
   });
   const results = await dynamoDocClient.send(command);

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -78,7 +78,7 @@ export const sendSqsMessage = async (
 };
 
 export const handler = async (event: SQSEvent): Promise<void> => {
-  const { QUEUE_URL } = process.env;
+  const { OUTPUT_QUEUE_URL } = process.env;
   const { Records } = event;
   await Promise.all(
     Records.map(async (record) => {
@@ -87,7 +87,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
       const results = await queryUserServices(txmaEvent.user.user_id);
       const messageId = await sendSqsMessage(
         createUserRecordEvent(txmaEvent, results),
-        QUEUE_URL
+        OUTPUT_QUEUE_URL
       );
       console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
     })

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -6,7 +6,13 @@ import {
 } from "@aws-sdk/client-sqs";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { Service, TxmaEvent, UserData, UserRecordEvent } from "./models";
+import {
+  Service,
+  TxmaEvent,
+  UserData,
+  UserRecordEvent,
+  UserServices,
+} from "./models";
 
 const { TABLE_NAME, AWS_REGION } = process.env;
 
@@ -30,7 +36,7 @@ export const queryUserServices = async (userId: string): Promise<Service[]> => {
   });
   const results = await dynamoDocClient.send(command);
 
-  return results.Item ? (results.Item as Service[]) : [];
+  return results.Item ? (results.Item as UserServices).services : [];
 };
 
 export const validateUser = (user: UserData): void => {

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -80,14 +80,16 @@ export const sendSqsMessage = async (
 export const handler = async (event: SQSEvent): Promise<void> => {
   const { QUEUE_URL } = process.env;
   const { Records } = event;
-  await Records.forEach(async (record) => {
-    const txmaEvent: TxmaEvent = JSON.parse(record.body);
-    validateTxmaEventBody(txmaEvent);
-    const results = await queryUserServices(txmaEvent.user.user_id);
-    const messageId = await sendSqsMessage(
-      createUserRecordEvent(txmaEvent, results),
-      QUEUE_URL
-    );
-    console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
-  });
+  await Promise.all(
+    Records.map(async (record) => {
+      const txmaEvent: TxmaEvent = JSON.parse(record.body);
+      validateTxmaEventBody(txmaEvent);
+      const results = await queryUserServices(txmaEvent.user.user_id);
+      const messageId = await sendSqsMessage(
+        createUserRecordEvent(txmaEvent, results),
+        QUEUE_URL
+      );
+      console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
+    })
+  );
 };

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -2,7 +2,13 @@ import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { SQSEvent, SQSRecord } from "aws-lambda";
 import { mockClient } from "aws-sdk-client-mock";
-import { Service, TxmaEvent, UserData, UserRecordEvent } from "../models";
+import {
+  Service,
+  TxmaEvent,
+  UserData,
+  UserRecordEvent,
+  UserServices,
+} from "../models";
 import "aws-sdk-client-mock-jest";
 import {
   handler,
@@ -58,12 +64,18 @@ describe("queryUserServices", () => {
       last_accessed: new Date(),
     },
   ];
+
+  const userServices: UserServices = {
+    user_id: "user-id",
+    services: serviceList,
+  };
+
   beforeEach(() => {
     dynamoMock.reset();
 
     process.env.TABLE_NAME = TABLE_NAME;
 
-    dynamoMock.on(GetCommand).resolves({ Item: serviceList });
+    dynamoMock.on(GetCommand).resolves({ Item: userServices });
   });
 
   afterEach(() => {
@@ -241,13 +253,18 @@ describe("handler", () => {
     },
   ];
 
+  const userServices: UserServices = {
+    user_id: "user-id",
+    services: serviceList,
+  };
+
   beforeEach(() => {
     dynamoMock.reset();
     sqsMock.reset();
     process.env.TABLE_NAME = TABLE_NAME;
-    process.env.QUEUE_URL = MOCK_QUEUE_URL;
+    process.env.OUTPUT_QUEUE_URL = MOCK_QUEUE_URL;
     sqsMock.on(SendMessageCommand).resolves({ MessageId: MOCK_MESSAGE_ID });
-    dynamoMock.on(GetCommand).resolves({ Item: serviceList });
+    dynamoMock.on(GetCommand).resolves({ Item: userServices });
   });
 
   afterEach(() => {


### PR DESCRIPTION
This PR fixes several small bugs to get the lambda functions all working together. We can now put an event on the input queue, see it processed by each lambda and end up in DynamoDB. 

The largest bug was that we weren't resolving the `Promise`s in the handler function for the first two lambdas, which meant the lambda stopped running before the messages got put on the queue to the next lambda. We were iterating over each record using `.forEach`, but that doesn't collect the returned objects and so discards the `Promise`s. We've now switched to `Records.map` which returns an array of `Promise`s, which we then wait to resolve using `await Promise.all( ... )`. 

We may want to tweak this behaviour in the future (perhaps with [`Promise.allSettled()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) ) to better allow us to do error catching per event, but we'll tackle that later - this PR is only about setting up the happy path.

---

It's probably easiest to review this commit by commit.  

This stack is deployed to the `dev` AWS account, we can test it by putting an event on the input queue and looking at the lambda logs in Cloudwatch and the DynamoDB table:

```bash
gds aws di-account-dev -- aws sqs send-message \
  --queue-url https://sqs.eu-west-2.amazonaws.com/985326104449/account-management-backend-TxMAInputDummyQueue-dKQby3vNf8m7 \
  --message-body '{"event_name":"event-name","timestamp":1666169856,"client_id":"client-id","component_id":"component-id","user":{"user_id":"user_id"}}'
```

If you change the user ID in the message body then look at the [summary of DynamoDB](https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#table?initialTagKey=&name=user_services&tab=overview) you can see more entries being added to the table.