### PR TITLE
BAU: Add initial README and licence

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,19 @@
+Copyright (C) 2022 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# di-account-management-backend
+
+The backend and data store that serves the account management application.
+
+This is a serverless application for AWS. It's built and deployed using the [SAM CLI](https://aws.amazon.com/serverless/sam/).
+
+## Testing
+
+Each Lambda function is a separate NPM application and has its own unit tests.
+
+To run the tests for the `query-user-services` Lambda:
+
+```bash
+cd lambda/query-user-services
+npm ci
+npm run lint
+npm run test
+```
+
+## Deploying the application
+
+Deploy the application to the `dev` AWS account by running
+
+```bash
+cd infrastructure
+sam build
+gds aws di-account-dev -- sam deploy
+```


### PR DESCRIPTION
We can add to the README as we work more things out - for example end-to-end tests or running a Lambda locally.