### PR TITLE
GUA - 431 dead letter queues

### DIFF
--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -4,13 +4,7 @@ import {
   SQSClient,
 } from "@aws-sdk/client-sqs";
 import { SQSEvent, SQSRecord } from "aws-lambda";
-import type {
-  UserData,
-  UserRecordEvent,
-  UserServices,
-  Service,
-  TxmaEvent,
-} from "./models";
+import type { UserData, UserRecordEvent, Service, TxmaEvent } from "./models";
 
 const { AWS_REGION } = process.env;
 
@@ -114,13 +108,13 @@ export const formatRecord = (record: UserRecordEvent) => {
 };
 
 export const sendSqsMessage = async (
-  messageBody: UserServices,
+  messageBody: string,
   queueUrl: string | undefined
 ): Promise<string | undefined> => {
   const client = new SQSClient({ region: AWS_REGION });
   const message: SendMessageRequest = {
     QueueUrl: queueUrl,
-    MessageBody: JSON.stringify(messageBody),
+    MessageBody: messageBody,
   };
   const result = await client.send(new SendMessageCommand(message));
   return result.MessageId;
@@ -135,13 +129,13 @@ export const handler = async (event: SQSEvent): Promise<void> => {
       try {
         const formattedRecord = formatRecord(validateAndParseSQSRecord(record));
         const messageId = await sendSqsMessage(
-          formattedRecord,
+          JSON.stringify(formattedRecord),
           OUTPUT_QUEUE_URL
         );
         console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
       } catch (err) {
         console.error(err);
-        await sendSqsMessage(JSON.parse(record.body), DLQ_URL);
+        await sendSqsMessage(record.body, DLQ_URL);
       }
     })
   );

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -206,16 +206,16 @@ describe("sendSqsMessage", () => {
     jest.clearAllMocks();
   });
 
-  const userRecordEvents: UserServices = {
+  const userRecordEvents: string = JSON.stringify({
     user_id: "user1234",
     services: [makeServiceRecord("client1234", 1)],
-  };
+  });
   test("Send the SQS event on the queue", async () => {
     const messageId = await sendSqsMessage(userRecordEvents, queueURL);
     expect(messageId).toEqual(messageID);
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
       QueueUrl: queueURL,
-      MessageBody: JSON.stringify(userRecordEvents),
+      MessageBody: userRecordEvents,
     });
   });
 });

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -18,7 +18,7 @@ import {
   makeServiceRecord,
   makeSQSInputFixture,
 } from "./testHelpers";
-import { UserServices, Service, TxmaEvent } from "../models";
+import { UserServices, Service } from "../models";
 
 const sqsMock = mockClient(SQSClient);
 
@@ -314,8 +314,6 @@ describe("handler error handling ", () => {
   const messageID = "MyMessageId";
   const sqsQueueName = "ToWriteSQS";
   const queueURL = "http://my_queue_url";
-  const userId = "userID1234";
-  const serviceClientID = "clientID1234";
   let consoleErrorMock: jest.SpyInstance;
   beforeEach(() => {
     consoleErrorMock = jest.spyOn(global.console, "error").mockImplementation();

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -71,13 +71,13 @@ const createUserRecordEvent = (
 };
 
 export const sendSqsMessage = async (
-  messageBody: object,
+  messageBody: string,
   queueUrl: string | undefined
 ): Promise<string | undefined> => {
   const client = new SQSClient({ region: AWS_REGION });
   const message: SendMessageRequest = {
     QueueUrl: queueUrl,
-    MessageBody: JSON.stringify(messageBody),
+    MessageBody: messageBody,
   };
   const result = await client.send(new SendMessageCommand(message));
   return result.MessageId;
@@ -93,13 +93,13 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         validateTxmaEventBody(txmaEvent);
         const results = await queryUserServices(txmaEvent.user.user_id);
         const messageId = await sendSqsMessage(
-          createUserRecordEvent(txmaEvent, results),
+          JSON.stringify(createUserRecordEvent(txmaEvent, results)),
           OUTPUT_QUEUE_URL
         );
         console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
       } catch (err) {
         console.error(err);
-        await sendSqsMessage(JSON.parse(record.body), DLQ_URL);
+        await sendSqsMessage(record.body, DLQ_URL);
       }
     })
   );

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -233,7 +233,10 @@ describe("sendSqsMessage", () => {
   });
   test("Send the SQS event on the queue", async () => {
     sqsMock.on(SendMessageCommand).resolves({ MessageId: MOCK_MESSAGE_ID });
-    const messageId = await sendSqsMessage(userRecordEvents, MOCK_QUEUE_URL);
+    const messageId = await sendSqsMessage(
+      JSON.stringify(userRecordEvents),
+      MOCK_QUEUE_URL
+    );
     expect(messageId).toEqual(MOCK_MESSAGE_ID);
     expect(
       sqsMock.commandCalls(SendMessageCommand, {


### PR DESCRIPTION
This PR adds the Dead Letter queue configuration to the format user service and query user service lambda. 
- If an error of any kind occurs during the process the record is sent to the Dead Letter Queue.
- I have also included some fix for linting errors in `format-user-services.test.ts` regarding an unused var.
- Also renamed format-user-record.test to format-user-service to match the handler ts.