### PR TITLE
GUA-438: Exclude test files from deployed Lambdas

### DIFF
--- a/lambda/format-user-services/tsconfig.json
+++ b/lambda/format-user-services/tsconfig.json
@@ -1,16 +1,16 @@
 {
-  "compilerOptions": {
-    "target": "es2020",
-    "strict": true,
-    "preserveConstEnums": true,
-    "noEmit": true,
-    "sourceMap": true,
-    "module": "es2015",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "types": ["jest", "node"]
-  },
-  "exclude": ["node_modules"]
+    "compilerOptions": {
+        "target": "es2020",
+        "strict": true,
+        "preserveConstEnums": true,
+        "noEmit": true,
+        "sourceMap": true,
+        "module": "es2015",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": ["jest", "node"]
+    },
+    "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/lambda/query-user-services/tsconfig.json
+++ b/lambda/query-user-services/tsconfig.json
@@ -12,5 +12,5 @@
         "forceConsistentCasingInFileNames": true,
         "types": ["jest", "node"]
     },
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/lambda/write-user-services/tsconfig.json
+++ b/lambda/write-user-services/tsconfig.json
@@ -12,5 +12,5 @@
         "forceConsistentCasingInFileNames": true,
         "types": ["jest", "node"]
     },
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
We removed the `exclude` directive for the test files in #2 to get VSCode to recognise that tests were run with Jest and not show errors for unknown functions.

Further testing has shown we only need the extra `types` entry added there, and VSCode is happy when the test files are added back to the exclusion list.

This change doesn't seem to have reduced the size of the deployed Lambdas like I was expecting. `sam build` uses ESBuild under the hood to transpile Typescript into Javascript and it's possible that was already ignoring the test files. In either case this change does make our config more similar to other teams on the programme.

---

To review, checkout this branch, open a test file in VSCode and check that it's not full of error messages when we use `describe()` or `test()`.