### PR TITLE
GUA-432: Trigger alarms when the DLQs receive a message

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -94,6 +94,8 @@ Resources:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
 
   QueryUserServicesRole:
     Type: AWS::IAM::Role
@@ -199,6 +201,8 @@ Resources:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
 
   FormatUserServicesRole:
     Type: AWS::IAM::Role
@@ -295,6 +299,8 @@ Resources:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
 
   WriteServiceRecordRole:
     Type: AWS::IAM::Role

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -146,6 +146,20 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
+  QueryDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt QueryUserServicesDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+
   #######################
   # Formatting the Record
   #######################
@@ -228,6 +242,20 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
+  FormatDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt FormatUserServicesDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+
   ###################
   # Write the Record
   ###################
@@ -309,3 +337,17 @@ Resources:
           - !Sub
             - '${Arn}/*'
             - Arn: !GetAtt UserServicesStore.Arn
+
+  WriteDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt WriteUserServicesDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -243,7 +243,7 @@ Resources:
             Queue: !GetAtt UserServicesToWriteQueue.Arn
       DeadLetterQueue:
         Type: SQS
-        TargetArn: !GetAtt WriteServicesDeadLetterQueue.Arn
+        TargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
       Handler: write-user-services.handler
       PackageType: Zip
       MemorySize: 128
@@ -253,7 +253,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_URL: !Ref WriteServicesDeadLetterQueue
+          DLQ_URL: !Ref WriteUserServicesDeadLetterQueue
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -263,7 +263,7 @@ Resources:
         EntryPoints:
         - write-user-services.ts
 
-  WriteServicesDeadLetterQueue:
+  WriteUserServicesDeadLetterQueue:
     Type: AWS::SQS::Queue
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
@@ -299,7 +299,7 @@ Resources:
         - Effect: Allow
           Action:
           - sqs:SendMessage
-          Resource: !GetAtt WriteServicesDeadLetterQueue.Arn
+          Resource: !GetAtt WriteUserServicesDeadLetterQueue.Arn
         - Effect: Allow
           Action:
           - dynamodb:PutItem


### PR DESCRIPTION
Set up a Cloudwatch alarm for each of the dead letter queues that's triggered when there's at least one message unprocessed in the queue.

The `ApproximateNumberOfMessagesVisible` metric seemed the most appropriate of those available [[1]. It's an approximation, but it'll always be greater than 0 if there's at least one message which is fine for this use case where we don't care how many messages there are.

There was also `NumberOfMessagesSent` which is "The number of messages added to a queue" but I wasn't sure if that would also be triggered if the whole Lambda failed to run and AWS put the message onto the DLQ, rather than us calling `sendMessage` from inside the lambdas.

For now these alarms don't do anything - we'll tackle sending notifications to Slack in future PRs.

---
I've deployed these alarms to the `dev` AWS account. You can see [an example here](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarmsV2:alarm/account-management-backend-QueryDeadLetterQueueAlarm-IQ8IGKC99MIU?) where I put an event on a DLQ, the alarm triggered, then I purged the queue and the alarm reset.

[1]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html