### PR TITLE
GUA-432: Send a message to Slack when an alarm is triggered 

### DIFF
--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -18,7 +18,8 @@ parameter_overrides=[
     "Environment=dev",
     "UserServicesStoreTableName=\"user_services\"",
     "CodeSigningConfigArn=none",
-    "PermissionsBoundary=none"
+    "PermissionsBoundary=none",
+    "SlackChannelId=C011Y5SAY3U"
 ]
 
 [dev.deploy.parameters]

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -167,6 +167,7 @@ Resources:
   QueryDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Join [ "-", [ !Ref AWS::StackName, !Ref Environment, QueryDeadLetterQueueAlarm ] ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
       Dimensions:
@@ -177,6 +178,9 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Ref AlarmNotificationTopic
+      ActionsEnabled: true
 
   #######################
   # Formatting the Record
@@ -265,6 +269,7 @@ Resources:
   FormatDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Join [ "-", [ !Ref AWS::StackName, !Ref Environment, FormatDeadLetterQueueAlarm ] ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
       Dimensions:
@@ -275,6 +280,9 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Ref AlarmNotificationTopic
+      ActionsEnabled: true
 
   ###################
   # Write the Record
@@ -363,6 +371,7 @@ Resources:
   WriteDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Join [ "-", [ !Ref AWS::StackName, !Ref Environment, WriteDeadLetterQueueAlarm ] ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
       Dimensions:
@@ -373,6 +382,9 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Ref AlarmNotificationTopic
+      ActionsEnabled: true
 
   #######################
   # Monitoring

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -16,6 +16,22 @@ Parameters:
       - "integration"
       - "production"
     ConstraintDescription: must be dev, build, staging, integration or production
+  SlackWorkspaceId:
+    Description: >
+      The ID of the Slack workspace where build notification messages are
+      posted. This is retrieved from the AWS Chatbot integration.
+    Type: String
+    Default: "T8GT9416G"
+    AllowedPattern: "\\w+"
+    ConstraintDescription: "must be an AWS Chatbot Slack workspace ID"
+
+  SlackChannelId:
+    Description: >
+      The ID of the Slack channel where build notification messages are posted.
+      This is taken from the channel details in Slack.
+    Type: String
+    AllowedPattern: "\\w+"
+    ConstraintDescription: "must be a Slack channel ID"
 
 Resources:
   ######################################
@@ -357,3 +373,44 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
+
+  #######################
+  # Monitoring
+  #######################
+  AlarmNotificationTopic:
+    Type: AWS::SNS::Topic
+
+  AlarmNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref AlarmNotificationTopic
+      PolicyDocument:
+        Statement:
+          - Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref AlarmNotificationTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+
+  ChatbotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "chatbot.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+  ChatbotChannelConfiguration:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Properties:
+      ConfigurationName: !Sub "${AWS::StackName}-slack-notifications"
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackChannelId: !Ref SlackChannelId
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SnsTopicArns:
+        - !Ref AlarmNotificationTopic


### PR DESCRIPTION
Set up AWS Chatbot to send messages to our Slack channel, mostly following what the dev platform pipeline [[1]] already does. Then add actions to each of the alarms to send a message to the new SNS topic when they're triggered.

This puts a message in Slack when an alarm goes off - see an example [here](https://gds.slack.com/archives/C011Y5SAY3U/p1666615861541789). Since that test message we've added the environment name to the alarm name so it's obvious which environment the alarm is for.

This Slack message topic and Chatbot config are prime candidates for moving to the central infrastructure stacks the Bravo team are writing. We may even not need the Chatbot config as one also gets created for the pipeline. We can consider that refactor when the central templates are ready.

[1]: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3062726680/How+to+prepare+AWS+accounts+for+containing+SAM+deployment+pipelines