### PR TITLE
BAU: Update prerequisites and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ nvm install
 
 from the root of the repository or in any `lambda/` folder to install the correct version on Node.
 
+We transpile and package the Lambda functions using `sam build`. This needs `esbuild` installed globally:
+
+```
+npm install -g esbuild
+```
+
 ## Testing
 
 Each Lambda function is a separate NPM application and has its own unit tests.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ cd infrastructure
 sam build
 gds aws di-account-dev -- sam deploy
 ```
+
+Once the application is deployed to `dev` we can test it by adding a fake event to the input queue:
+
+1. Open the AWS console for the `dev` account (`gds aws di-account-dev`) and go to [the SQS page](https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues).
+2. Find the input queue for your stack and copy the queue URL.
+3. Send an event to the queue using the AWS CLI:
+
+```bash
+gds aws di-account-dev -- aws sqs send-message \
+  --queue-url QUEUE_URL \
+  --message-body '{"event_name":"event-name","timestamp":1666169856,"client_id":"client-id","component_id":"component-id","user":{"user_id":"user_id"}}'
+```


### PR DESCRIPTION
Adds `esbuild` as a dependency since this is required for `sam build`.

Also add instructions to send a test event to the application's input queue.