### PR TITLE
GUA-435: Restrict deploy action to `main`

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -3,6 +3,8 @@ name: SAM app test and build and deploy
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
We removed this restriction while we were setting up the deploy action and missed adding it back before we merged.

Add it back so this action only runs when a pull request is merged to `main`.