### PR TITLE
GUA-469 delete lambda

### DIFF
--- a/lambda/delete-user-services/delete-user-services.ts
+++ b/lambda/delete-user-services/delete-user-services.ts
@@ -12,7 +12,6 @@ import {
 } from "@aws-sdk/client-sqs";
 import { UserData } from "./models";
 
-const { TABLE_NAME } = process.env;
 const marshallOptions = {
   convertClassInstanceToMap: true,
 };
@@ -25,7 +24,6 @@ const dynamoDocClient = DynamoDBDocumentClient.from(
 );
 
 const sqsClient = new SQSClient({});
-const { DLQ_URL } = process.env;
 
 export const validateUserData = (userData: UserData): UserData => {
   if (userData.user_id) {
@@ -37,6 +35,8 @@ export const validateUserData = (userData: UserData): UserData => {
 export const deleteUserData = async (
   userData: UserData
 ): Promise<DeleteCommandOutput> => {
+  const { TABLE_NAME } = process.env;
+
   const command = new DeleteCommand({
     TableName: TABLE_NAME,
     Key: { user_id: userData.user_id },
@@ -45,6 +45,8 @@ export const deleteUserData = async (
 };
 
 export const handler = async (event: SNSEvent): Promise<void> => {
+  const { DLQ_URL } = process.env;
+
   await Promise.all(
     event.Records.map(async (record) => {
       try {

--- a/lambda/delete-user-services/delete-user-services.ts
+++ b/lambda/delete-user-services/delete-user-services.ts
@@ -1,4 +1,4 @@
-import { SQSEvent } from "aws-lambda";
+import { SNSEvent } from "aws-lambda";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
@@ -44,18 +44,18 @@ export const deleteUserData = async (
   return dynamoDocClient.send(command);
 };
 
-export const handler = async (event: SQSEvent): Promise<void> => {
+export const handler = async (event: SNSEvent): Promise<void> => {
   await Promise.all(
     event.Records.map(async (record) => {
       try {
-        const userData: UserData = JSON.parse(record.body);
+        const userData: UserData = JSON.parse(record.Sns.Message);
         validateUserData(userData);
         await deleteUserData(userData);
       } catch (err) {
         console.error(err);
         const message: SendMessageRequest = {
           QueueUrl: DLQ_URL,
-          MessageBody: record.body,
+          MessageBody: record.Sns.Message,
         };
         await sqsClient.send(new SendMessageCommand(message));
       }

--- a/lambda/delete-user-services/tests/delete-user-services.test.ts
+++ b/lambda/delete-user-services/tests/delete-user-services.test.ts
@@ -7,7 +7,7 @@ import {
   deleteUserData,
 } from "../delete-user-services";
 
-import { TEST_USER_DATA, TEST_SQS_EVENT } from "./testHelpers";
+import { TEST_USER_DATA, TEST_SNS_EVENT } from "./testHelpers";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 const sqsMock = mockClient(SQSClient);
@@ -41,7 +41,7 @@ describe("handler", () => {
   });
 
   test("it iterates over each record in the batch", async () => {
-    await handler(TEST_SQS_EVENT);
+    await handler(TEST_SNS_EVENT);
     expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(2);
   });
 
@@ -60,12 +60,12 @@ describe("handler", () => {
     });
 
     test("logs the error message", async () => {
-      await handler(TEST_SQS_EVENT);
+      await handler(TEST_SNS_EVENT);
       expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     });
 
     test("sends the event to the dead letter queue", async () => {
-      await handler(TEST_SQS_EVENT);
+      await handler(TEST_SNS_EVENT);
       expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
     });
   });

--- a/lambda/delete-user-services/tests/delete-user-services.test.ts
+++ b/lambda/delete-user-services/tests/delete-user-services.test.ts
@@ -1,0 +1,91 @@
+import { DynamoDBDocumentClient, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  handler,
+  validateUserData,
+  deleteUserData,
+} from "../delete-user-services";
+
+import { TEST_USER_DATA, TEST_SQS_EVENT } from "./testHelpers";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+const sqsMock = mockClient(SQSClient);
+
+describe("deleteUserData", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("deletes item from DynamoDB", async () => {
+    await deleteUserData(TEST_USER_DATA);
+    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(1);
+  });
+});
+
+describe("handler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    sqsMock.reset();
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("it iterates over each record in the batch", async () => {
+    await handler(TEST_SQS_EVENT);
+    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(2);
+  });
+
+  describe("error handling", () => {
+    let consoleErrorMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleErrorMock = jest
+        .spyOn(global.console, "error")
+        .mockImplementation();
+      dynamoMock.rejectsOnce("mock error");
+    });
+
+    afterEach(() => {
+      consoleErrorMock.mockRestore();
+    });
+
+    test("logs the error message", async () => {
+      await handler(TEST_SQS_EVENT);
+      expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("sends the event to the dead letter queue", async () => {
+      await handler(TEST_SQS_EVENT);
+      expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+    });
+  });
+});
+
+describe("validateUserData", () => {
+  test("doesn't throw an error with valid data", () => {
+    expect(validateUserData(TEST_USER_DATA)).toBe(TEST_USER_DATA);
+  });
+
+  describe("throws an error", () => {
+    test("when user_id is missing", () => {
+      const userData = JSON.parse(
+        JSON.stringify({
+          foo: "bar",
+        })
+      );
+      expect(() => {
+        validateUserData(userData);
+      }).toThrowError();
+    });
+  });
+});

--- a/lambda/delete-user-services/tests/delete-user-services.test.ts
+++ b/lambda/delete-user-services/tests/delete-user-services.test.ts
@@ -1,3 +1,4 @@
+import "aws-sdk-client-mock-jest";
 import { DynamoDBDocumentClient, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { mockClient } from "aws-sdk-client-mock";
@@ -25,7 +26,10 @@ describe("deleteUserData", () => {
 
   test("deletes item from DynamoDB", async () => {
     await deleteUserData(TEST_USER_DATA);
-    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(1);
+    expect(dynamoMock).toHaveReceivedCommandWith(DeleteCommand, {
+      TableName: process.env.TABLE_NAME,
+      Key: { user_id: TEST_USER_DATA.user_id },
+    });
   });
 });
 

--- a/lambda/delete-user-services/tests/testHelpers.ts
+++ b/lambda/delete-user-services/tests/testHelpers.ts
@@ -1,0 +1,26 @@
+import type { SQSEvent, SQSRecord } from "aws-lambda";
+
+export const TEST_USER_DATA = {
+  user_id: "user-id",
+};
+
+const TEST_SQS_RECORD: SQSRecord = {
+  messageId: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+  receiptHandle: "MessageReceiptHandle",
+  body: JSON.stringify(TEST_USER_DATA),
+  attributes: {
+    ApproximateReceiveCount: "1",
+    SentTimestamp: "1523232000000",
+    SenderId: "123456789012",
+    ApproximateFirstReceiveTimestamp: "1523232000001",
+  },
+  messageAttributes: {},
+  md5OfBody: "7b270e59b47ff90a553787216d55d91d",
+  eventSource: "aws:sqs",
+  eventSourceARN: "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+  awsRegion: "us-east-1",
+};
+
+export const TEST_SQS_EVENT: SQSEvent = {
+  Records: [TEST_SQS_RECORD, TEST_SQS_RECORD],
+};

--- a/lambda/delete-user-services/tests/testHelpers.ts
+++ b/lambda/delete-user-services/tests/testHelpers.ts
@@ -1,26 +1,30 @@
-import type { SQSEvent, SQSRecord } from "aws-lambda";
+import type { SNSEvent, SNSMessage, SNSEventRecord } from "aws-lambda";
 
 export const TEST_USER_DATA = {
   user_id: "user-id",
 };
 
-const TEST_SQS_RECORD: SQSRecord = {
-  messageId: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
-  receiptHandle: "MessageReceiptHandle",
-  body: JSON.stringify(TEST_USER_DATA),
-  attributes: {
-    ApproximateReceiveCount: "1",
-    SentTimestamp: "1523232000000",
-    SenderId: "123456789012",
-    ApproximateFirstReceiveTimestamp: "1523232000001",
-  },
-  messageAttributes: {},
-  md5OfBody: "7b270e59b47ff90a553787216d55d91d",
-  eventSource: "aws:sqs",
-  eventSourceARN: "arn:aws:sqs:us-east-1:123456789012:MyQueue",
-  awsRegion: "us-east-1",
+const TEST_SNS_MESSAGE: SNSMessage = {
+  SignatureVersion: "SignatureVersion",
+  Timestamp: "Timestamp",
+  Signature: "Signature",
+  SigningCertUrl: "SigningCertUrl",
+  MessageId: "MessageId",
+  Message: JSON.stringify(TEST_USER_DATA),
+  MessageAttributes: {},
+  Type: "Type",
+  UnsubscribeUrl: "unsubscribeUrl",
+  TopicArn: "TopicArn",
+  Subject: "Subject",
 };
 
-export const TEST_SQS_EVENT: SQSEvent = {
-  Records: [TEST_SQS_RECORD, TEST_SQS_RECORD],
+const TEST_SNS_EVENT_RECORD: SNSEventRecord = {
+  EventVersion: "1",
+  EventSubscriptionArn: "arn",
+  EventSource: "source",
+  Sns: TEST_SNS_MESSAGE,
+};
+
+export const TEST_SNS_EVENT: SNSEvent = {
+  Records: [TEST_SNS_EVENT_RECORD, TEST_SNS_EVENT_RECORD],
 };


### PR DESCRIPTION
## How to test

1. Pre-populate a dynamoDB record with our target user_id
```bash
gds aws di-account-dev -- aws dynamodb put-item \
    --table-name user_services \
    --item '{ "user_id": { "S": "test-to-delete"}}'
```
Or, [create an item in the AWS console](https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#edit-item?table=user_services&route=ROUTE_ITEM_EXPLORER&itemMode=1) with `user_id` = "test-to-delete"

2. Query to check that your new record is there:
```bash
gds aws di-account-dev -- aws dynamodb get-item \
      --table-name user_services \
      --key '{"user_id": {"S": "test-to-delete"}}'
```

or to see all entries:
```bash
gds aws di-account-dev -- aws dynamodb scan --table-name user_services
```

You can also explore the [AWS console here](https://eu-west-2.console.aws.amazon.com/dynamodbv2/home?region=eu-west-2#item-explorer?initialTagKey=&table=user_services)

3. Get the ARN for your SNS topic

Either check in the console, [starting here](https://eu-west-2.console.aws.amazon.com/sns/v3/home?region=eu-west-2#/topics)

OR

```bash
 gds aws di-account-dev -- aws di-account-dev -- aws sns list-topics
```

4. Fire an SNS event

```
 gds aws di-account-dev -- aws sns publish \
    --topic-arn SNS_TOPIC_ARN_HERE \
    --message '{ "user_id": "test-to-delete" }'
```

5. Repeat step (2) to see if there's still a dynamoDB entry