### PR TITLE
Add function name to Lambda to create a log group 

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -101,7 +101,10 @@ Resources:
   ######################
   QueryUserServicesFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - QueryUserServicesFunctionLogGroup
     Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-query-user-services
       Architectures: ["x86_64"]
       CodeUri: ../lambda/query-user-services/
       Events:
@@ -255,7 +258,10 @@ Resources:
   #######################
   FormatUserServicesFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - FormatUserServicesFunctionLogGroup
     Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-format-user-services
       Architectures: ["x86_64"]
       CodeUri: ../lambda/format-user-services/
       Events:
@@ -395,7 +401,10 @@ Resources:
   ###################
   WriteUserServicesFunction:
     Type: AWS::Serverless::Function
+    DependsOn:
+      - WriteUserServicesFunctionLogGroup
     Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-write-user-services
       Architectures: ["x86_64"]
       CodeUri: ../lambda/write-user-services/
       Events:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -100,8 +100,6 @@ Resources:
   # Querying the Record
   ######################
   QueryUserServicesFunction:
-    DependsOn:
-      - QueryUserServicesFunctionLogGroup
     Type: AWS::Serverless::Function
     Properties:
       Architectures: ["x86_64"]
@@ -134,13 +132,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - query-user-services.ts
-
-  QueryUserServicesFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "${AWS::StackName}-query-user-service-log-group"
-      RetentionInDays: 30
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   QueryUserServicesDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -215,6 +206,20 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - cloudwatch:PutMetricData
+            Resource: !GetAtt QueryUserServicesFunctionLogGroup.Arn
+
+  QueryUserServicesFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-query-user-services"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   UserServicesToFormatQueue:
     Type: AWS::SQS::Queue
@@ -249,8 +254,6 @@ Resources:
   # Formatting the Record
   #######################
   FormatUserServicesFunction:
-    DependsOn:
-      - FormatUserServicesFunctionLogGroup
     Type: AWS::Serverless::Function
     Properties:
       Architectures: ["x86_64"]
@@ -282,13 +285,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - format-user-services.ts
-
-  FormatUserServicesFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "${AWS::StackName}-format-user-service-log-group"
-      RetentionInDays: 30
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   FormatUserServicesDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -350,6 +346,20 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt LambdaKMSKey.Arn
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - cloudwatch:PutMetricData
+            Resource: !GetAtt FormatUserServicesFunctionLogGroup.Arn
+
+  FormatUserServicesFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-format-user-services"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   UserServicesToWriteQueue:
     Type: AWS::SQS::Queue
@@ -384,8 +394,6 @@ Resources:
   # Write the Record
   ###################
   WriteUserServicesFunction:
-    DependsOn:
-      - WriteUserServicesFunctionLogGroup
     Type: AWS::Serverless::Function
     Properties:
       Architectures: ["x86_64"]
@@ -417,13 +425,6 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - write-user-services.ts
-
-  WriteUserServicesFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "${AWS::StackName}-write-user-service-log-group"
-      RetentionInDays: 30
-      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   WriteUserServicesDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -494,6 +495,20 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              - cloudwatch:PutMetricData
+            Resource: !GetAtt WriteUserServicesFunctionLogGroup.Arn
+
+  WriteUserServicesFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-write-user-services"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   WriteDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -209,13 +209,6 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt DatabaseKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              - cloudwatch:PutMetricData
-            Resource: !GetAtt QueryUserServicesFunctionLogGroup.Arn
 
   QueryUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -352,13 +345,6 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt LambdaKMSKey.Arn
-          - Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              - cloudwatch:PutMetricData
-            Resource: !GetAtt FormatUserServicesFunctionLogGroup.Arn
 
   FormatUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -504,13 +490,6 @@ Resources:
             Action:
               - kms:*
             Resource: !GetAtt DatabaseKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:CreateLogStream
-              - logs:PutLogEvents
-              - cloudwatch:PutMetricData
-            Resource: !GetAtt WriteUserServicesFunctionLogGroup.Arn
 
   WriteUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Custom log group names are not allowed in AWS and they follow the pattern of /aws/lambda/{functionName} . Add function name to the lambdas to create the correct Log Group Name. 

Thanks to @alex9smith 