### PR TITLE
GUA 499 : Update the permission of key on Lambda Policy

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -195,20 +195,12 @@ Resources:
                 - Arn: !GetAtt UserServicesStore.Arn
           - Effect: Allow
             Action:
-              - kms:*
-            Resource: !GetAtt QueueKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LoggingKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LambdaKMSKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt DatabaseKmsKey.Arn
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+            - !GetAtt QueueKmsKey.Arn
+            - !GetAtt DatabaseKmsKey.Arn
 
   QueryUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -335,16 +327,10 @@ Resources:
             Resource: !GetAtt UserServicesToWriteQueue.Arn
           - Effect: Allow
             Action:
-              - kms:*
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
             Resource: !GetAtt QueueKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LoggingKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LambdaKMSKey.Arn
 
   FormatUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -476,20 +462,12 @@ Resources:
                 - Arn: !GetAtt UserServicesStore.Arn
           - Effect: Allow
             Action:
-              - kms:*
-            Resource: !GetAtt QueueKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LoggingKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt LambdaKMSKey.Arn
-          - Effect: Allow
-            Action:
-              - kms:*
-            Resource: !GetAtt DatabaseKmsKey.Arn
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+            - !GetAtt QueueKmsKey.Arn
+            - !GetAtt DatabaseKmsKey.Arn
 
   WriteUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -556,20 +556,7 @@ Resources:
               - "*"
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action:
-              - kms:*
-            Resource:
-              - "*"
-          - Effect: Allow
-            Principal:
               Service: cloudwatch.amazonaws.com
-            Action: kms:*
-            Resource:
-              - "*"
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
             Action: kms:*
             Resource:
               - "*"
@@ -594,12 +581,6 @@ Resources:
               - kms:*
             Resource:
               - "*"
-          - Effect: "Allow"
-            Principal:
-              Service: "lambda.amazonaws.com"
-            Action:
-              - "kms:*"
-            Resource: "*"
 
   DatabaseKmsKeyAlias:
     Type: AWS::KMS::Alias
@@ -625,7 +606,7 @@ Resources:
             Principal:
               Service: "lambda.amazonaws.com"
             Action:
-              - "kms:*"
+              - "kms:Decrypt"
             Resource: "*"
 
   LambdaKMSKeyAlias:
@@ -644,12 +625,6 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - kms:*
-            Resource: "*"
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
             Action:
               - kms:*
             Resource: "*"


### PR DESCRIPTION
- Only allow lambda to perform creation actions when encrypting and decrypting. 
- Remove other policies that are not needed . 