### PR TITLE
GUA-512: Send lambda logs to Splunk

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -39,6 +39,12 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
+    
+  IsNotDevelopment:
+    Fn::Not:
+      - Fn::Equals:
+            - !Ref Environment
+            - "dev"
 
 Globals:
   Function:
@@ -209,6 +215,14 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
+  QueryUserServicesCSLSSubscription:
+    Condition: IsNotDevelopment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref QueryUserServicesFunctionLogGroup
+
   UserServicesToFormatQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -338,6 +352,14 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-format-user-services"
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  FormatUserServicesCSLSSubscription:
+    Condition: IsNotDevelopment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref FormatUserServicesFunctionLogGroup
 
   UserServicesToWriteQueue:
     Type: AWS::SQS::Queue
@@ -475,6 +497,14 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-write-user-services"
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  WriteUserServicesCSLSSubscription:
+    Condition: IsNotDevelopment
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref WriteUserServicesFunctionLogGroup
 
   WriteDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Sets up log subscription filters that send application logs from the lambdas to Splunk.

These aren't created in the `dev` AWS account. We don't have a CSLS config for `dev` and it doesn't make sense to create one since we share the non-production index with all environments and teams on DI. We don't want to accidentally fill that index with logs from our development environment while we're testing things out.

Because of that we'll have to test in `build` after merging this PR. That should be ok though, I'm pretty confident in these changes.