### PR TITLE
GUA-487: Create DynamoDB table for raw events

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -6,6 +6,9 @@ Parameters:
   UserServicesStoreTableName:
     Type: String
     Default: user_services
+  RawEventsStoreTableName:
+    Type: String
+    Default: raw_events
   Environment:
     Description: "The environment type"
     Type: "String"
@@ -65,7 +68,50 @@ Globals:
 
 Resources:
   ######################################
-  # Dynamo DB - Output target for system
+  # Raw events store
+  ######################################
+  RawEventsStore:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: timestamp
+          AttributeType: N
+      BillingMode: PAY_PER_REQUEST
+      TableName: !Ref RawEventsStoreTableName
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+        - AttributeName: timestamp
+          KeyType: RANGE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt DatabaseKmsKey.Arn
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
+      TimeToLiveSpecification:
+        AttributeName: remove_at
+        Enabled: true
+      Tags:
+        - Key: Product
+          Value: GOV.UK Sign In
+        - Key: System
+          Value: Account Management Backend
+        - Key: Owner
+          Value: govuk-accounts-tech@digital.cabinet-office.gov.uk
+        - Key: Environment
+          Value: !Ref "Environment"
+        - Key: Source
+          Value: "https://github.com/alphagov/di-account-management-backend/blob/main/infrastructure/template.yaml"
+
+  ######################################
+  # User services store
   ######################################
   UserServicesStore:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
This table has streams [[1]] enabled, which will become the input trigger for the `query-user-services` lambda. Items in this table will be written once and not updated, so I've used the `NEW_IMAGE` stream setting which will only include the newly written data in the stream event.

The table also has two keys - `id` and `timestamp`. DynamoDB requires a hash key that's used for the primary index. We don't want the lambda that writes these items to parse the TxMA event because that might fail, so we'll need to generate this ID in the lambda.

We're also using `timestamp` as a RANGE key. If we do ever need to use this table to replay events, it'll probably be over a time range. Using the timestamp as a key gives us a secondary index that'll speed up time-based queries.

We want to use Dynamo's TTL feature [[2]] to expire data in this table after a period of time. This requires a top-level attribute in the item that is:
1. a Number type
2. a timestamp in Unix epoch time format in seconds
3. not more than 5 years ago [[3]]

Dynamo will regularly scan the table and delete items that are older than the timestamp in this attribute. If the attribute's not present in an item, DynamoDB won't delete it. I've called this attribute `remove_at`, and the lambda writing these items will need to generate a timestamp in the future and include this attribute.

[1]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
[2]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
[3]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/howitworks-ttl.html