### PR TITLE
GUA-487: Switch user services pipeline to Dynamo stream

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -166,10 +166,19 @@ Resources:
       Architectures: ["x86_64"]
       CodeUri: ../lambda/query-user-services/
       Events:
-        TxMAInputDummyQueue:
-          Type: SQS
+        DynamoStream:
+          Type: DynamoDB
           Properties:
-            Queue: !GetAtt TxMAInputDummyQueue.Arn
+            BatchSize: 1
+            Stream: !GetAtt RawEventsStore.StreamArn
+            Enabled: true
+            DestinationConfig:
+              OnFailure:
+                Destination: !GetAtt QueryUserServicesDeadLetterQueue.Arn
+            StartingPosition: LATEST
+            FilterCriteria:
+              Filters:
+                - Pattern: '{ "eventName": ["INSERT"]'
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt QueryUserServicesDeadLetterQueue.Arn
@@ -253,6 +262,10 @@ Resources:
             Action:
               - dynamodb:Query
               - dynamodb:GetItem
+              - dynamodb:DescribeStream
+              - dynamodb:GetRecords
+              - dynamodb:GetShardIterator
+              - dynamodb:ListStreams
             Resource:
               - !GetAtt UserServicesStore.Arn
               - !Sub

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -262,15 +262,22 @@ Resources:
             Action:
               - dynamodb:Query
               - dynamodb:GetItem
-              - dynamodb:DescribeStream
-              - dynamodb:GetRecords
-              - dynamodb:GetShardIterator
-              - dynamodb:ListStreams
             Resource:
               - !GetAtt UserServicesStore.Arn
               - !Sub
                 - "${Arn}/*"
                 - Arn: !GetAtt UserServicesStore.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeStream
+              - dynamodb:GetRecords
+              - dynamodb:GetShardIterator
+              - dynamodb:ListStreams
+            Resource:
+              - !GetAtt RawEventsStore.StreamArn
+              - !Sub
+                - "${Arn}/*"
+                - Arn: !GetAtt RawEventsStore.StreamArn
           - Effect: Allow
             Action:
               - kms:Decrypt

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -178,7 +178,7 @@ Resources:
             StartingPosition: LATEST
             FilterCriteria:
               Filters:
-                - Pattern: '{ "eventName": ["INSERT"]'
+                - Pattern: '{ "eventName": ["INSERT"] }'
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt QueryUserServicesDeadLetterQueue.Arn


### PR DESCRIPTION
Switches the first lambda in the user services pipeline to use the DynamoDB table stream added in #44. This is part of the work to update the system architecture to reflect [ADR 0004](https://github.com/alphagov/di-account-management-backend/blob/main/docs/adr/0004-store-all-event-data.md).

This lambda is only subscribed to events when new items are written to the table. We're also enabling DynamoDB's TTL feature on this table, and we don't want the delete events from that to cause errors or (worse) be treated as new events.