### PR TITLE
GUA-468 delete stack alerting

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -718,6 +718,32 @@ Resources:
               ArnEquals:
                 "aws:SourceArn": !Ref UserAccountDeletionTopic
 
+  UserAccountDeletionTopicDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            UserAccountDeletionTopicDeadLetterQueueAlarm,
+          ],
+        ]
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt UserAccountDeletionTopicDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Ref AlarmNotificationTopic
+      ActionsEnabled: true
+
   DeleteDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -713,7 +713,7 @@ Resources:
             Principal:
               Service: sns.amazonaws.com
             Action: "sqs:SendMessage"
-            Resource: !Ref UserAccountDeletionTopicDeadLetterQueue
+            Resource: !GetAtt UserAccountDeletionTopicDeadLetterQueue.Arn
             Condition:
               ArnEquals:
                 "aws:SourceArn": !Ref UserAccountDeletionTopic


### PR DESCRIPTION
WIP whilst I test

## How to test

### SNS Topic Alerts trigger

#### Prerequisites

Check the topic SQS DLQ exists:
https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-UserAccountDeletionTopicDeadLetterQueue-gZpDthtNx75m

Check an Alarm is present for the DLQ:
https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarmsV2:alarm/account-mgmt-backend-dev-UserAccountDeletionTopicDeadLetterQueueAlarm?

Check that the it is not in the alarm state.

#### Add an event to the queue and check for alarm

```
gds aws di-account-dev -- aws sqs send-message --queue-url https://sqs.eu-west-2.amazonaws.com/985326104449/account-mgmt-backend-UserAccountDeletionTopicDeadLetterQueue-gZpDthtNx75m --message-body "Test the alarm system"
```

Check that there is [1 message on the queue](https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-UserAccountDeletionTopicDeadLetterQueue-gZpDthtNx75m)

[Check that the alarm has gone off in AWS console](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarmsV2:alarm/account-mgmt-backend-dev-UserAccountDeletionTopicDeadLetterQueueAlarm?)

Check that you have recieved an email titled:
> ALARM: "account-mgmt-backend-dev-UserAccountDeletionTopicDeadLetterQueueAlarm" in EU (London)
Inbox

#### Once you are done
[Purge the DLQ](https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-UserAccountDeletionTopicDeadLetterQueue-gZpDthtNx75m) There's a button on the top right next to Delete

### Delete Lambda DLQ

#### Prerequisites

Check the topic SQS DLQ exists:
https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-DeleteUserServicesDeadLetterQueue-oRaAT30LQz35

Check an Alarm is present for the DLQ:
https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarmsV2:alarm/account-mgmt-backend-dev-DeleteDeadLetterQueueAlarm?

Check that the it is not in the alarm state.

#### Add an event to the queue and check for alarm

```
gds aws di-account-dev -- aws sqs send-message --queue-url https://sqs.eu-west-2.amazonaws.com/985326104449/account-mgmt-backend-DeleteUserServicesDeadLetterQueue-oRaAT30LQz35 --message-body "Test the alarm system"
```

Check that there is [1 message on the queue](https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-DeleteUserServicesDeadLetterQueue-oRaAT30LQz35)

[Check that the alarm has gone off in AWS console](hhttps://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#alarmsV2:alarm/account-mgmt-backend-dev-DeleteDeadLetterQueueAlarm?)

Check that you have recieved an email titled:
> ALARM: "account-mgmt-backend-dev-DeleteDeadLetterQueueAlarm" in EU (London)
Inbox

#### Once you are done
[Purge the DLQ](https://eu-west-2.console.aws.amazon.com/sqs/v2/home?region=eu-west-2#/queues/https%3A%2F%2Fsqs.eu-west-2.amazonaws.com%2F985326104449%2Faccount-mgmt-backend-DeleteUserServicesDeadLetterQueue-oRaAT30LQz35) There's a button on the top right next to Delete

## Test the integration

### Invoke the lambda with a purposefully dodgy set of params

Aim here is to check that the DLQ gets written to if the lambda fails in any way.

Starting with a quieted alarm and empty DLQ invoke:

Visit the [Lambda function](https://eu-west-2.console.aws.amazon.com/lambda/home?region=eu-west-2#/functions/dev-account-mgmt-backend-delete-user-services?tab=code) in aws console. Select "Configure test event" and under template select "SNS Topic Notification".

Save this and hit test. This will be a roughly valid shaped SNS event, but the message is just an example string which should fail.

You should see a new item on the DLQ.

### Delete the lambda and write an SNS topic

Aim here is to check that the DLQ gets written to if the lambda is not present

Starting with a quieted alarm and empty topic DLQ.

Go find the lambda in AWS console and delete it.

Get the ARN for your SNS topic
Either check in the console, [starting here](https://eu-west-2.console.aws.amazon.com/sns/v3/home?region=eu-west-2#/topics)

OR

```bash
 gds aws di-account-dev -- aws di-account-dev -- aws sns list-topics
```

Fire an SNS event

```
 gds aws di-account-dev -- aws sns publish \
    --topic-arn SNS_TOPIC_ARN_HERE \
    --message '{ "user_id": "test-to-delete" }'
```

You should see one Item on the Topic DLQ