### PR TITLE
GUA-514: Set values for `QueueArn` in all environments

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -74,8 +74,16 @@ Globals:
 
 Mappings:
   InputQueue:
+    dev: 
+      QueueArn: ""
+    build: 
+      QueueArn: ""
     staging: 
       QueueArn: "arn:aws:sqs:eu-west-2:178023842775:PublishToAccountsSQSQueue-staging"
+    integration: 
+      QueueArn: ""
+    production: 
+      QueueArn: ""
 
 Resources:
   ######################################

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -58,6 +58,8 @@ Conditions:
   UseInternalEvents: !Or
     - !Equals [ !Ref Environment, dev ]
     - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
 
 Globals:
   Function:


### PR DESCRIPTION
These need to be in place because CloudFormation evaluates both sides of the if statement for the queue ARN on line 190 before filling in the correct value.

If there's not a value in the mapping for each environment the template fails to deploy with an error like

```
Status: FAILED. Reason: Template error: Unable to get mapping for InputQueue::build::QueueArn
```

Also change the condition so that it's only true for staging at the moment. This hasn't caused any errors yet, but it would have done if the template had got as far as integration.