### PR TITLE
GUA-514: Log record on error

### DIFF
--- a/lambda/save-raw-events/save-raw-events.ts
+++ b/lambda/save-raw-events/save-raw-events.ts
@@ -84,6 +84,7 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         await writeRawTxmaEvent(txmaEvent);
       } catch (err) {
         console.error(err);
+        console.log(record);
         const message: SendMessageRequest = {
           QueueUrl: DLQ_URL,
           MessageBody: record.body,

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -234,6 +234,7 @@ describe("handler", () => {
 
 describe("handler error handling", () => {
   let consoleErrorMock: jest.SpyInstance;
+  let consoleLogMock: jest.SpyInstance;
 
   beforeEach(() => {
     dynamoMock.reset();
@@ -241,15 +242,21 @@ describe("handler error handling", () => {
     process.env.TABLE_NAME = "TABLE_NAME";
     process.env.DLQ_URL = "DLQ_URL";
     consoleErrorMock = jest.spyOn(global.console, "error").mockImplementation();
+    consoleLogMock = jest.spyOn(global.console, "log").mockImplementation();
     dynamoMock.rejectsOnce("mock error");
   });
   afterEach(() => {
     consoleErrorMock.mockRestore();
+    consoleLogMock.mockRestore();
     jest.clearAllMocks();
   });
   test("logs the error message", async () => {
     await handler(TEST_SQS_EVENT);
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+  });
+  test("logs the record", async () => {
+    await handler(TEST_SQS_EVENT);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
   });
   test("sends the event to the dead letter queue", async () => {
     await handler(TEST_SQS_EVENT);


### PR DESCRIPTION
To aid with debugging the integration with TxMA.

We'll want to revert this before we deploy the backend to production to make sure we don't log any personal or sensitive data.