### PR TITLE
GUA-470: Add the SNS topic ARN as a SSM parameter

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -632,6 +632,14 @@ Resources:
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: UserAccountDeletion
 
+  UserAccountDeletionTopicArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: !Sub "The ARN of the ${AWS::StackName} UserAccountDeletionTopic"
+      Name: !Sub "/${AWS::StackName}/SNS/DeleteTopic/ARN"
+      Type: String
+      Value: !Ref UserAccountDeletionTopic
+
   DeleteUserServicesSubscription:
     Type: AWS::SNS::Subscription
     Properties:


### PR DESCRIPTION
We'll need to be able to get this ARN into our frontend stack, but as the cloudformation lives in separate template files, the way we're going to exchange it is to have this deploy write the ARN to an SSM parameter, which we can then call out of the frontend stack.