### PR TITLE
GUA-470: Ship the SNS KMS Key ID as an SSM parameter

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1188,3 +1188,11 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/SnsKmsKey"
       TargetKeyId: !Ref SnsKmsKey
+
+  SnsKmsKeyIDParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the SNS KMS Key
+      Name: !Sub "/${AWS::StackName}/KMS/SnsKmsKey/ID"
+      Type: String
+      Value: !Ref SnsKmsKey


### PR DESCRIPTION
We'll need to pick up on this in the frontend application