### PR TITLE
GUA-462 add db kms to ssm

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1097,6 +1097,14 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/DatabaseKmsKey"
       TargetKeyId: !Ref DatabaseKmsKey
 
+  DatabaseKmsKeyIDParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the Database KMS Key
+      Name: !Sub "/${AWS::StackName}/KMS/DatabaseKmsKey/ID"
+      Type: String
+      Value: !Ref DatabaseKmsKey
+
   LambdaKMSKey:
     Type: AWS::KMS::Key
     Properties:


### PR DESCRIPTION
- Fix to avoid errors "message": "KMS key access denied error: "  on the front end while trying to read from her_services dynamo DB. 