### PR TITLE
GUA-514 changes to txma data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ Once the application is deployed to `dev` we can test it by adding a fake event 
 ```bash
 gds aws di-account-dev -- aws sqs send-message \
   --queue-url QUEUE_URL \
-  --message-body '{"event_name":"event-name","timestamp":1666169856,"client_id":"client-id","component_id":"component-id","user":{"user_id":"user_id"}}'
+  --message-body '{"event_name":"event-name","timestamp":1666169856,"client_id":"client-id","user":{"user_id":"user_id"}}'
 ```

--- a/docs/adr/0003-recording-service-usage-in-account.md
+++ b/docs/adr/0003-recording-service-usage-in-account.md
@@ -81,7 +81,7 @@ export interface UserServices {
 export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
-  last_accessed: Date;
+  last_accessed: number;
 }
 ```
 

--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -44,7 +44,6 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
     txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
-    txmaEvent.component_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);

--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -41,9 +41,9 @@ const validateUser = (user: UserData): void => {
 
 const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
   if (
-    txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
+    txmaEvent.client_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);
@@ -70,7 +70,7 @@ export const newServicePresenter = (TxmaEvent: TxmaEvent): Service => ({
 
 export const existingServicePresenter = (
   service: Service,
-  lastAccessed: string
+  lastAccessed: number
 ): Service => ({
   client_id: service.client_id,
   count_successful_logins: service.count_successful_logins + 1,

--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -9,18 +9,21 @@ export interface UserRecordEvent {
 export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
-  last_accessed: string;
+  last_accessed: number;
 }
 
 export interface TxmaEvent {
+  event_id: string;
+  timestamp: number;
+  timestamp_formatted: string;
   event_name: string;
-  timestamp: string;
   client_id: ClientId;
   user: UserData;
 }
 
 export interface UserData {
   user_id: UrnFdnSub;
+  govuk_signin_journey_id: string;
 }
 
 export interface UserServices {

--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -16,7 +16,6 @@ export interface TxmaEvent {
   event_name: string;
   timestamp: string;
   client_id: ClientId;
-  component_id: string;
   user: UserData;
 }
 

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -29,7 +29,7 @@ describe("newServicePresenter", () => {
     expect(newServicePresenter(TXMA_EVENT)).toEqual({
       client_id: "clientID1234",
       count_successful_logins: 1,
-      last_accessed: "2022-01-01T12:00:00.000Z",
+      last_accessed: 1670850655485,
     });
   });
 });
@@ -38,9 +38,9 @@ describe("existingServicePresenter", () => {
   const existingServiceRecord = makeServiceRecord(
     "clientID1234",
     4,
-    "2022-01-01T12:00:00.000Z"
+    1670850655485
   );
-  const lastAccessed = "2022-02-01T12:00:00.000Z";
+  const lastAccessed = 1670850655485;
 
   test("modifies existing Service record", () => {
     expect(
@@ -248,9 +248,7 @@ describe("handler", () => {
     ]);
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
-      services: [
-        makeServiceRecord(serviceClientID, 1, "2022-01-01T12:00:00.000Z"),
-      ],
+      services: [makeServiceRecord(serviceClientID, 1, 1670850655485)],
     };
     await handler({ Records: inputSQSEvent });
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
@@ -261,7 +259,7 @@ describe("handler", () => {
 
   test("it writes a formatted SQS event when TxMA event matched a stored user service", async () => {
     const serviceListWithExistingService = [
-      makeServiceRecord(serviceClientID, 10, "2022-01-01T12:00:00.000Z"),
+      makeServiceRecord(serviceClientID, 10, 1670850655485),
     ] as Service[];
     const inputSQSEvent = makeSQSInputFixture([
       {
@@ -271,9 +269,7 @@ describe("handler", () => {
     ]);
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
-      services: [
-        makeServiceRecord(serviceClientID, 11, "2022-01-01T12:00:00.000Z"),
-      ],
+      services: [makeServiceRecord(serviceClientID, 11, 1670850655485)],
     };
     await handler({ Records: inputSQSEvent });
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
@@ -286,7 +282,7 @@ describe("handler", () => {
     const anotherService = makeServiceRecord(
       "anotherClientId",
       10,
-      "2022-01-01T12:00:00.000Z"
+      1670850655485
     );
 
     const inputSQSEvent = makeSQSInputFixture([
@@ -298,7 +294,7 @@ describe("handler", () => {
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
       services: [
-        makeServiceRecord(serviceClientID, 1, "2022-01-01T12:00:00.000Z"),
+        makeServiceRecord(serviceClientID, 1, 1670850655485),
         anotherService,
       ],
     };

--- a/lambda/format-user-services/tests/testHelpers.ts
+++ b/lambda/format-user-services/tests/testHelpers.ts
@@ -40,7 +40,6 @@ export const makeTxmaEvent = (clientId: string, userId: string): TxmaEvent => ({
   event_name: "event_1",
   timestamp: "2022-01-01T12:00:00.000Z",
   client_id: clientId,
-  component_id: "component_id",
   user: {
     user_id: userId,
   },

--- a/lambda/format-user-services/tests/testHelpers.ts
+++ b/lambda/format-user-services/tests/testHelpers.ts
@@ -10,11 +10,11 @@ import type {
 export const makeServiceRecord = (
   clientId: string,
   count: number,
-  date?: string
+  date?: number
 ): Service => ({
   client_id: clientId,
   count_successful_logins: count,
-  last_accessed: date || new Date().toISOString(),
+  last_accessed: date || new Date().valueOf(),
 });
 
 export const makeSQSEventFixture = (
@@ -38,10 +38,13 @@ export const makeSQSEventFixture = (
 
 export const makeTxmaEvent = (clientId: string, userId: string): TxmaEvent => ({
   event_name: "event_1",
-  timestamp: "2022-01-01T12:00:00.000Z",
+  event_id: "event_id",
+  timestamp: 1670850655485,
+  timestamp_formatted: "2022-12-12T13:10:55.485Z",
   client_id: clientId,
   user: {
     user_id: userId,
+    govuk_signin_journey_id: "abc123",
   },
 });
 

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -17,7 +17,7 @@ export interface TxmaEvent {
 export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
-  last_accessed: Date;
+  last_accessed: number;
 }
 
 export interface UserData {

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -5,9 +5,12 @@ export interface UserServices {
   user_id: UrnFdnSub;
   services: Service[];
 }
+
 export interface TxmaEvent {
+  event_id: string;
+  timestamp: number;
+  timestamp_formatted: string;
   event_name: string;
-  timestamp: string;
   client_id: ClientId;
   user: UserData;
 }
@@ -16,9 +19,12 @@ export interface Service {
   count_successful_logins: number;
   last_accessed: Date;
 }
+
 export interface UserData {
   user_id: UrnFdnSub;
+  govuk_signin_journey_id: string;
 }
+
 export interface UserRecordEvent {
   TxmaEvent: TxmaEvent;
   ServiceList: Service[];

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -9,7 +9,6 @@ export interface TxmaEvent {
   event_name: string;
   timestamp: string;
   client_id: ClientId;
-  component_id: string;
   user: UserData;
 }
 export interface Service {

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -48,9 +48,9 @@ export const validateUser = (user: UserData): void => {
 
 export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
-    txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
+    txmaEvent.client_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);

--- a/lambda/query-user-services/query-user-services.ts
+++ b/lambda/query-user-services/query-user-services.ts
@@ -51,7 +51,6 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
-    txmaEvent.component_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -19,13 +19,19 @@ import {
 } from "../query-user-services";
 
 const userId = "user_id";
-const timestamp = new Date().valueOf().toString();
+const date = new Date();
+const timestamp = date.valueOf();
+const timestampFormatted = date.toISOString();
+const govukSigninJourneyId = "abc123";
 const user: UserData = {
   user_id: userId,
+  govuk_signin_journey_id: govukSigninJourneyId,
 };
 const TEST_TXMA_EVENT: TxmaEvent = {
+  event_id: "event_id",
   event_name: "event_name",
   timestamp,
+  timestamp_formatted: timestampFormatted,
   client_id: "client_id",
   user,
 };
@@ -43,11 +49,17 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
       timestamp: { N: `${Date.now()}` },
       event: {
         M: {
+          event_id: {
+            S: "event_id",
+          },
           event_name: {
             S: "event_name",
           },
           timestamp: {
-            S: timestamp,
+            N: `${timestamp}`,
+          },
+          timestamp_formatted: {
+            S: timestampFormatted,
           },
           client_id: {
             S: "client_id",
@@ -56,6 +68,9 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
             M: {
               user_id: {
                 S: userId,
+              },
+              govuk_signin_journey_id: {
+                S: govukSigninJourneyId,
               },
             },
           },

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -95,7 +95,7 @@ describe("queryUserServices", () => {
     {
       client_id: "client_id",
       count_successful_logins: 2,
-      last_accessed: new Date(),
+      last_accessed: new Date().valueOf(),
     },
   ];
 
@@ -230,7 +230,7 @@ describe("sendSqsMessage", () => {
       {
         client_id: "client_id",
         count_successful_logins: 2,
-        last_accessed: new Date(),
+        last_accessed: new Date().valueOf(),
       },
     ],
   };
@@ -262,7 +262,7 @@ describe("handler", () => {
     {
       client_id: "client_id",
       count_successful_logins: 2,
-      last_accessed: new Date(),
+      last_accessed: new Date().valueOf(),
     },
   ];
 
@@ -289,7 +289,7 @@ describe("handler", () => {
       {
         client_id: "client_id",
         count_successful_logins: 2,
-        last_accessed: new Date(),
+        last_accessed: new Date().valueOf(),
       },
     ],
   };

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -27,7 +27,6 @@ const TEST_TXMA_EVENT: TxmaEvent = {
   event_name: "event_name",
   timestamp,
   client_id: "client_id",
-  component_id: "component_id",
   user,
 };
 
@@ -52,9 +51,6 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
           },
           client_id: {
             S: "client_id",
-          },
-          component_id: {
-            S: "component_id",
           },
           user: {
             M: {
@@ -124,7 +120,6 @@ describe("validateTxmaEventBody", () => {
           {
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
             user: {
               user_id: "user_id",
             },
@@ -143,7 +138,6 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: "client_id",
             event_name: "event_name",
-            component_id: "component_id",
             user: {
               user_id: "user_id",
             },
@@ -162,26 +156,6 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: "client_id",
             timestamp: new Date().toISOString,
-            component_id: "component_id",
-            user: {
-              user_id: "user_id",
-            },
-          },
-        ],
-      })
-    );
-    expect(() => {
-      validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
-  });
-  test("throws error when component_id is missing", () => {
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [
-          {
-            client_id: "client_id",
-            timestamp: new Date().toISOString,
-            event_name: "event_name",
             user: {
               user_id: "user_id",
             },
@@ -201,7 +175,6 @@ describe("validateTxmaEventBody", () => {
             client_id: "client_id",
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
           },
         ],
       })
@@ -218,7 +191,6 @@ describe("validateTxmaEventBody", () => {
             client_id: "client_id",
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
             user: {},
           },
         ],

--- a/lambda/save-raw-events/models.ts
+++ b/lambda/save-raw-events/models.ts
@@ -2,13 +2,15 @@ type UrnFdnSub = string;
 type ClientId = string;
 
 export interface TxmaEvent {
+  event_id: string;
+  timestamp: number;
+  timestamp_formatted: string;
   event_name: string;
-  timestamp: string;
   client_id: ClientId;
-  component_id: string;
   user: UserData;
 }
 
 export interface UserData {
   user_id: UrnFdnSub;
+  govuk_signin_journey_id: string;
 }

--- a/lambda/save-raw-events/save-raw-events.ts
+++ b/lambda/save-raw-events/save-raw-events.ts
@@ -47,7 +47,6 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
-    txmaEvent.component_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);

--- a/lambda/save-raw-events/save-raw-events.ts
+++ b/lambda/save-raw-events/save-raw-events.ts
@@ -44,9 +44,9 @@ export const validateUser = (user: UserData): void => {
 
 export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
-    txmaEvent.client_id !== undefined &&
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
+    txmaEvent.client_id !== undefined &&
     txmaEvent.user !== undefined
   ) {
     validateUser(txmaEvent.user);

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -100,10 +100,12 @@ describe("validateTxmaEventBody", () => {
       JSON.stringify({
         services: [
           {
-            timestamp: new Date().toISOString,
+            timestamp: date.valueOf(),
+            timestamp_formatted: date.toISOString(),
             event_name: "event_name",
             user: {
               user_id: "user_id",
+              govuk_signin_journey_id: "abc123",
             },
           },
         ],
@@ -119,9 +121,11 @@ describe("validateTxmaEventBody", () => {
         services: [
           {
             client_id: "client_id",
+            timestamp_formatted: date.toISOString(),
             event_name: "event_name",
             user: {
               user_id: "user_id",
+              govuk_signin_journey_id: "abc123",
             },
           },
         ],
@@ -137,9 +141,11 @@ describe("validateTxmaEventBody", () => {
         services: [
           {
             client_id: "client_id",
-            timestamp: new Date().toISOString,
+            timestamp: date.valueOf(),
+            timestamp_formatted: date.toISOString(),
             user: {
               user_id: "user_id",
+              govuk_signin_journey_id: "abc123",
             },
           },
         ],
@@ -155,7 +161,8 @@ describe("validateTxmaEventBody", () => {
         services: [
           {
             client_id: "client_id",
-            timestamp: new Date().toISOString,
+            timestamp: date.valueOf(),
+            timestamp_formatted: date.toISOString(),
             event_name: "event_name",
           },
         ],
@@ -165,13 +172,14 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
   });
-  test("throws error when user_id  is missing", () => {
+  test("throws error when user_id is missing", () => {
     const txmaEvent = JSON.parse(
       JSON.stringify({
         services: [
           {
             client_id: "client_id",
-            timestamp: new Date().toISOString,
+            timestamp: date.valueOf(),
+            timestamp_formatted: date.toISOString(),
             event_name: "event_name",
             user: {},
           },

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -18,14 +18,20 @@ const sqsMock = mockClient(SQSClient);
 const userId = "user_id";
 const user: UserData = {
   user_id: userId,
+  govuk_signin_journey_id: "govuk_signin_journey_id",
 };
+
+const date = new Date();
+
 const TEST_TXMA_EVENT: TxmaEvent = {
-  event_name: "event_1",
-  timestamp: new Date().toISOString(),
+  event_id: "ab12345a-a12b-3ced-ef12-12a3b4cd5678",
+  timestamp: date.getTime(),
+  timestamp_formatted: date.toISOString(),
+  event_name: "AUTH_AUTH_CODE_ISSUED",
   client_id: "client_id",
-  component_id: "component_id",
   user,
 };
+
 const TEST_SQS_RECORD: SQSRecord = {
   messageId: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
   receiptHandle: "MessageReceiptHandle",
@@ -96,7 +102,6 @@ describe("validateTxmaEventBody", () => {
           {
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
             user: {
               user_id: "user_id",
             },
@@ -115,7 +120,6 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: "client_id",
             event_name: "event_name",
-            component_id: "component_id",
             user: {
               user_id: "user_id",
             },
@@ -134,26 +138,6 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: "client_id",
             timestamp: new Date().toISOString,
-            component_id: "component_id",
-            user: {
-              user_id: "user_id",
-            },
-          },
-        ],
-      })
-    );
-    expect(() => {
-      validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
-  });
-  test("throws error when component_id is missing", () => {
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [
-          {
-            client_id: "client_id",
-            timestamp: new Date().toISOString,
-            event_name: "event_name",
             user: {
               user_id: "user_id",
             },
@@ -173,7 +157,6 @@ describe("validateTxmaEventBody", () => {
             client_id: "client_id",
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
           },
         ],
       })
@@ -190,7 +173,6 @@ describe("validateTxmaEventBody", () => {
             client_id: "client_id",
             timestamp: new Date().toISOString,
             event_name: "event_name",
-            component_id: "component_id",
             user: {},
           },
         ],

--- a/lambda/write-user-services/models.ts
+++ b/lambda/write-user-services/models.ts
@@ -9,5 +9,5 @@ export interface UserServices {
 export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
-  last_accessed: Date;
+  last_accessed: number;
 }

--- a/lambda/write-user-services/tests/write-user-services.test.ts
+++ b/lambda/write-user-services/tests/write-user-services.test.ts
@@ -15,7 +15,7 @@ const TEST_USER_SERVICES: UserServices = {
   services: [
     {
       client_id: "client_id",
-      last_accessed: new Date(),
+      last_accessed: new Date().valueOf().valueOf(),
       count_successful_logins: 1,
     },
   ],
@@ -116,7 +116,7 @@ describe("validateUserServices", () => {
           services: [
             {
               client_id: "client_id",
-              last_accessed: new Date(),
+              last_accessed: new Date().valueOf().valueOf(),
               count_successful_logins: 1,
             },
           ],
@@ -144,7 +144,7 @@ describe("validateUserServices", () => {
           user_id: "user-id",
           services: [
             {
-              last_accessed: new Date(),
+              last_accessed: new Date().valueOf(),
               count_successful_logins: 1,
             },
           ],
@@ -167,7 +167,7 @@ describe("validateServices", () => {
       JSON.stringify([
         {
           client_id: "client_id",
-          last_accessed: new Date(),
+          last_accessed: new Date().valueOf(),
           count_successful_logins: 1,
         },
       ])
@@ -180,7 +180,7 @@ describe("validateServices", () => {
       const services = parseServices(
         JSON.stringify([
           {
-            last_accessed: new Date(),
+            last_accessed: new Date().valueOf(),
             count_successful_logins: 1,
           },
         ])
@@ -209,7 +209,7 @@ describe("validateServices", () => {
         JSON.stringify([
           {
             client_id: "client-id",
-            last_accessed: new Date(),
+            last_accessed: new Date().valueOf(),
           },
         ])
       );
@@ -223,7 +223,7 @@ describe("validateServices", () => {
         JSON.stringify([
           {
             client_id: "client-id",
-            last_accessed: new Date(),
+            last_accessed: new Date().valueOf(),
             count_successful_logins: -1,
           },
         ])


### PR DESCRIPTION
Update TxMA event payload expectations, broadly:
- remove component_id, that's no longer coming through
- update TxMA payloads to reflect data we know we're getting
- keep validation to only things we know we want to use
- Cascade dates through the system as Epoch numbers, as I'm suspicious about `Date` class instances making it back when we're coming in and out of Dynamo and JSON parsing. Let's expect numbers, parse them as epochs where we need them