### PR TITLE
GUA-462 Prettify dates

### DIFF
--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -54,6 +54,12 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
   }
 };
 
+export const prettifyDate = (dateEpoch: number): string => {
+  return new Intl.DateTimeFormat("en-GB", { dateStyle: "long" }).format(
+    new Date(dateEpoch)
+  );
+};
+
 export const validateAndParseSQSRecord = (
   record: SQSRecord
 ): UserRecordEvent => {

--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -12,7 +12,8 @@ const validateUserService = (service: Service): void => {
       service.client_id !== undefined &&
       service.count_successful_logins &&
       service.count_successful_logins >= 0 &&
-      service.last_accessed !== undefined
+      service.last_accessed !== undefined &&
+      service.last_accessed_pretty !== undefined
     )
   ) {
     throw new Error(`Could not validate Service ${JSON.stringify(service)}`);
@@ -74,6 +75,7 @@ export const newServicePresenter = (TxmaEvent: TxmaEvent): Service => ({
   client_id: TxmaEvent.client_id,
   count_successful_logins: 1,
   last_accessed: TxmaEvent.timestamp,
+  last_accessed_pretty: prettifyDate(TxmaEvent.timestamp),
 });
 
 export const existingServicePresenter = (
@@ -83,6 +85,7 @@ export const existingServicePresenter = (
   client_id: service.client_id,
   count_successful_logins: service.count_successful_logins + 1,
   last_accessed: lastAccessed,
+  last_accessed_pretty: prettifyDate(lastAccessed),
 });
 
 export const conditionallyUpsertServiceList = (

--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -10,6 +10,7 @@ export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
   last_accessed: number;
+  last_accessed_pretty: string;
 }
 
 export interface TxmaEvent {

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -10,6 +10,7 @@ import {
   sendSqsMessage,
   conditionallyUpsertServiceList,
   formatRecord,
+  prettifyDate,
   handler,
 } from "../format-user-services";
 
@@ -219,6 +220,13 @@ describe("sendSqsMessage", () => {
       QueueUrl: queueURL,
       MessageBody: userRecordEvents,
     });
+  });
+});
+
+describe("prettifyDate", () => {
+  test("It takes a date Epoch as a number and returns a pretty formatted date", async () => {
+    const date = new Date(2022, 0, 1);
+    expect(prettifyDate(date.valueOf())).toEqual("1 January 2022");
   });
 });
 

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -31,6 +31,7 @@ describe("newServicePresenter", () => {
       client_id: "clientID1234",
       count_successful_logins: 1,
       last_accessed: 1670850655485,
+      last_accessed_pretty: "12 December 2022",
     });
   });
 });
@@ -42,6 +43,9 @@ describe("existingServicePresenter", () => {
     1670850655485
   );
   const lastAccessed = 1670850655485;
+  const formattedDate = new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "long",
+  }).format(new Date(lastAccessed));
 
   test("modifies existing Service record", () => {
     expect(
@@ -51,6 +55,7 @@ describe("existingServicePresenter", () => {
       count_successful_logins:
         existingServiceRecord.count_successful_logins + 1,
       last_accessed: lastAccessed,
+      last_accessed_pretty: formattedDate,
     });
   });
 });

--- a/lambda/format-user-services/tests/testHelpers.ts
+++ b/lambda/format-user-services/tests/testHelpers.ts
@@ -11,11 +11,18 @@ export const makeServiceRecord = (
   clientId: string,
   count: number,
   date?: number
-): Service => ({
-  client_id: clientId,
-  count_successful_logins: count,
-  last_accessed: date || new Date().valueOf(),
-});
+): Service => {
+  const fallbackDate = new Date(2022, 0, 1).valueOf();
+  const formattedDate = new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "long",
+  }).format(new Date(date || fallbackDate));
+  return {
+    client_id: clientId,
+    count_successful_logins: count,
+    last_accessed: date || fallbackDate,
+    last_accessed_pretty: formattedDate,
+  };
+};
 
 export const makeSQSEventFixture = (
   payloadBody: UserRecordEvent | UserServices

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -18,6 +18,7 @@ export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
   last_accessed: number;
+  last_accessed_pretty: string;
 }
 
 export interface UserData {

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -95,7 +95,10 @@ describe("queryUserServices", () => {
     {
       client_id: "client_id",
       count_successful_logins: 2,
-      last_accessed: new Date().valueOf(),
+      last_accessed: date.valueOf(),
+      last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+        dateStyle: "long",
+      }).format(date),
     },
   ];
 
@@ -230,7 +233,10 @@ describe("sendSqsMessage", () => {
       {
         client_id: "client_id",
         count_successful_logins: 2,
-        last_accessed: new Date().valueOf(),
+        last_accessed: date.valueOf(),
+        last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+          dateStyle: "long",
+        }).format(date),
       },
     ],
   };
@@ -262,7 +268,10 @@ describe("handler", () => {
     {
       client_id: "client_id",
       count_successful_logins: 2,
-      last_accessed: new Date().valueOf(),
+      last_accessed: date.valueOf(),
+      last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+        dateStyle: "long",
+      }).format(date),
     },
   ];
 
@@ -289,7 +298,10 @@ describe("handler", () => {
       {
         client_id: "client_id",
         count_successful_logins: 2,
-        last_accessed: new Date().valueOf(),
+        last_accessed: date.valueOf(),
+        last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+          dateStyle: "long",
+        }).format(date),
       },
     ],
   };

--- a/lambda/write-user-services/models.ts
+++ b/lambda/write-user-services/models.ts
@@ -10,4 +10,5 @@ export interface Service {
   client_id: ClientId;
   count_successful_logins: number;
   last_accessed: number;
+  last_accessed_pretty: string;
 }

--- a/lambda/write-user-services/tests/write-user-services.test.ts
+++ b/lambda/write-user-services/tests/write-user-services.test.ts
@@ -10,12 +10,17 @@ import {
 } from "../write-user-services";
 import { Service, UserServices } from "../models";
 
+const date = new Date();
+
 const TEST_USER_SERVICES: UserServices = {
   user_id: "user-id",
   services: [
     {
       client_id: "client_id",
-      last_accessed: new Date().valueOf().valueOf(),
+      last_accessed: date.valueOf(),
+      last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+        dateStyle: "long",
+      }).format(date),
       count_successful_logins: 1,
     },
   ],
@@ -167,7 +172,10 @@ describe("validateServices", () => {
       JSON.stringify([
         {
           client_id: "client_id",
-          last_accessed: new Date().valueOf(),
+          last_accessed: date.valueOf(),
+          last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+            dateStyle: "long",
+          }).format(date),
           count_successful_logins: 1,
         },
       ])
@@ -180,7 +188,10 @@ describe("validateServices", () => {
       const services = parseServices(
         JSON.stringify([
           {
-            last_accessed: new Date().valueOf(),
+            last_accessed: date.valueOf(),
+            last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+              dateStyle: "long",
+            }).format(date),
             count_successful_logins: 1,
           },
         ])
@@ -194,6 +205,24 @@ describe("validateServices", () => {
       const services = parseServices(
         JSON.stringify([
           {
+            client_id: "client-id",
+            count_successful_logins: 1,
+            last_accessed_pretty: new Intl.DateTimeFormat("en-GB", {
+              dateStyle: "long",
+            }).format(date),
+          },
+        ])
+      );
+      expect(() => {
+        validateServices(services);
+      }).toThrowError();
+    });
+
+    test("when last_accessed_pretty is missing", () => {
+      const services = parseServices(
+        JSON.stringify([
+          {
+            last_accessed: date.valueOf(),
             client_id: "client-id",
             count_successful_logins: 1,
           },

--- a/lambda/write-user-services/write-user-services.ts
+++ b/lambda/write-user-services/write-user-services.ts
@@ -33,7 +33,8 @@ export const validateServices = (services: Service[]): void => {
         service.client_id !== undefined &&
         service.count_successful_logins &&
         service.count_successful_logins >= 0 &&
-        service.last_accessed !== undefined
+        service.last_accessed !== undefined &&
+        service.last_accessed_pretty !== undefined
       )
     ) {
       throw new Error(`Could not validate Service ${JSON.stringify(service)}`);


### PR DESCRIPTION
The frontend is fairly naively consuming payloads out of dynamo.
To prevent complicating the controller / view, let's just add another field of formatted data.

Called it pretty becuase TxMA already has a ISO string with suffix `_formatted`, `_pretty` is intended to distinguish.