### PR TITLE
Fix checkov error on build pipeline add ReservedConcurrentExecutions to lambda function 

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -201,6 +201,7 @@ Resources:
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
+      ReservedConcurrentExecutions: 10
       Runtime: nodejs16.x
       Role: !GetAtt SaveRawEventsRole.Arn
       Timeout: 5
@@ -362,6 +363,7 @@ Resources:
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
+      ReservedConcurrentExecutions: 10
       Runtime: nodejs16.x
       Role: !GetAtt QueryUserServicesRole.Arn
       Timeout: 5
@@ -530,6 +532,7 @@ Resources:
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
+      ReservedConcurrentExecutions: 10
       Runtime: nodejs16.x
       Role: !GetAtt FormatUserServicesRole.Arn
       Timeout: 5
@@ -675,6 +678,7 @@ Resources:
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
+      ReservedConcurrentExecutions: 10
       Runtime: nodejs16.x
       Role: !GetAtt WriteServiceRecordRole.Arn
       Timeout: 5
@@ -849,6 +853,7 @@ Resources:
       KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
       MemorySize: 128
+      ReservedConcurrentExecutions: 10
       Runtime: nodejs16.x
       Role: !GetAtt DeleteUserServicesRole.Arn
       Timeout: 5


### PR DESCRIPTION
- Add ReservedConcurrentExecutions to the lambda functions to avoid checkov  error on build . 
![Screenshot 2023-01-12 at 11 37 28](https://user-images.githubusercontent.com/17740808/212057175-d1058c32-501c-495a-8b8b-caddfcb43b9a.png)

![Screenshot 2023-01-12 at 11 36 47](https://user-images.githubusercontent.com/17740808/212057943-708abb29-69cc-403c-b710-442a34f514d4.png)

We can see that in there are 4 events published per sec and by keeping the value of the ConcurrentExecutions at 10 we allow room for 20 events/sec. which is way above what we are seeing. 
