### PR TITLE
GUA-615: make prettifyDate formatter handle seconds and milliseconds

### DIFF
--- a/lambda/format-user-services/format-user-services.ts
+++ b/lambda/format-user-services/format-user-services.ts
@@ -56,8 +56,16 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
 };
 
 export const prettifyDate = (dateEpoch: number): string => {
+  let dateEpochInMilliSeconds: number;
+  if (dateEpoch.toString().length === 10) {
+    // Epoch is in seconds
+    dateEpochInMilliSeconds = dateEpoch * 1000;
+  } else {
+    // Epoch is in milliseconds
+    dateEpochInMilliSeconds = dateEpoch;
+  }
   return new Intl.DateTimeFormat("en-GB", { dateStyle: "long" }).format(
-    new Date(dateEpoch)
+    new Date(dateEpochInMilliSeconds)
   );
 };
 

--- a/lambda/format-user-services/tests/format-user-services.test.ts
+++ b/lambda/format-user-services/tests/format-user-services.test.ts
@@ -229,9 +229,14 @@ describe("sendSqsMessage", () => {
 });
 
 describe("prettifyDate", () => {
-  test("It takes a date Epoch as a number and returns a pretty formatted date", async () => {
-    const date = new Date(2022, 0, 1);
-    expect(prettifyDate(date.valueOf())).toEqual("1 January 2022");
+  test("It takes a date epoch in seconds and returns a pretty formatted date", async () => {
+    const dateEpoochInSeconds = 1673358736;
+    expect(prettifyDate(dateEpoochInSeconds)).toEqual("10 January 2023");
+  });
+
+  test("It takes a date epoch in milliseconds and returns a pretty formatted date", async () => {
+    const dateEpoochInSeconds = 2382450028987;
+    expect(prettifyDate(dateEpoochInSeconds)).toEqual("30 June 2045");
   });
 });
 


### PR DESCRIPTION
What?
Make prettifyDate formatter handle seconds and milliseconds.
Despite only seeing dateEpoch values from TxMA in seconds we have coded defensively to handle milliseconds as well as that is a more standard format. 

Why?
During integration testing we found that the dateEpoch from TXMA event was in seconds not milliseconds. The prettifyDate dateformatter in format-user-services lambda was setup to only handle milliseconds so was always returning the wrong date. 

