### PR TITLE
GUA-524 updating github workflow actions to node16 versions

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -53,19 +53,19 @@ jobs:
         run: npm ci && npm test
         working-directory: ./lambda/save-raw-events
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v1
+        uses: aws-actions/setup-sam@v2
 
       - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
         run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2


### PR DESCRIPTION
Proposed changes
Updating github workflow actions to versions written in Node 16.

Why did it change
Github is deprecating Node12 and for security deprecating the set-output function.

Checklists
Checked workflows that are triggered when branch is pushed, when deploying to dev, and when raising PR.
Workflows triggered on merge to main can only be confirmed when this PR is merged.