### PR TITLE
GUA-524 updating git workflow 'checkout' action to node16 version

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Proposed changes
GUA-524 updating git workflow 'checkout' action to node16 version

Why did it change
Github is deprecating Node12 and for security deprecating the set-output function.
Missed this one in previous PR because this workflow is not called till after merge to main. 

Checklists
Checked workflows that are triggered when branch is pushed, when deploying to dev, and when raising PR.
Workflows triggered on merge to main can only be confirmed when this PR is merged.