### PR TITLE
ATB-233: Added permission to QueueKmsKey resource so that SNS can access key and send undeliverable messages to the DLQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
 .aws-sam/
 build.toml
+.idea

--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -9,16 +9,12 @@ beta_features = true
 stack_name = "account-mgmt-backend"
 region = "eu-west-2"
 s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-44r43ey3knwx"
-s3_prefix = "account-management-backend"
+s3_prefix = "account-mgmt-backend"
 capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = true
 tags = "project=\"account-management-backend\" stage=\"dev\""
-parameter_overrides=[
-    "Environment=dev",
-    "UserServicesStoreTableName=\"user_services\"",
-    "CodeSigningConfigArn=none",
-    "PermissionsBoundary=none"
-]
+parameter_overrides = "UserServicesStoreTableName=\"user_services\" RawEventsStoreTableName=\"raw_events\" Environment=\"dev\" VpcStackName=\"vpc-enhanced\" CodeSigningConfigArn=\"none\" PermissionsBoundary=\"none\""
+image_repositories = []
 
 [dev.deploy.parameters]
 stack_name = "account-mgmt-backend"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1072,6 +1072,14 @@ Resources:
             Action: kms:*
             Resource:
               - "*"
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: 
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Resource:
+              - "*"
 
   QueueKmsKeyAlias:
     Type: AWS::KMS::Alias

--- a/lambda/.gitignore
+++ b/lambda/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-
 coverage/


### PR DESCRIPTION
## Proposed changes
Give `SNS` permission to access the `QueueKmsKey` so that it can send undeliverable messages to the `UserAccountDeletionTopicDeadLetterQueue`. Also adding `.idea` folder to `.gitignore`. 

### What changed
Permission was added to the `QueueKmsKey` resource to allow `SNS` to access this key.

### Why did it change
The `UserAccountDeletionTopic` is not sending to the `UserAccountDeletionTopicDeadLetterQueue` messages which it cannot deliver to the `DeleteUserServicesFunction` because it does not have permission to access the `QueueKmsKey`. 

### Issue tracking
- [ATB-233](https://govukverify.atlassian.net/browse/ATB-233)

## Checklists
### Testing

https://user-images.githubusercontent.com/110468919/216605712-2d9fe9c5-7573-4916-90dc-d7771b9d11e1.mp4



![queuekmskey-new-permissions](https://user-images.githubusercontent.com/110468919/216602842-a1906f8a-d1c0-41f5-9955-933f45e3cfd3.png)
![undeliverable-sns-message-in-dlq](https://user-images.githubusercontent.com/110468919/216602848-a2f86742-0b13-4b1b-9a71-a8e178e55cf9.png)




[ATB-233]: https://govukverify.atlassian.net/browse/ATB-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ