### PR TITLE
GUA-697 Update processor Architecture to arm64

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -196,7 +196,7 @@ Resources:
       - SaveRawEventsFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-save-raw-events
-      Architectures: ["x86_64"]
+      Architectures: ["arm64"]
       CodeUri: ../lambda/save-raw-events/
       Events:
         InputQueue:
@@ -352,7 +352,7 @@ Resources:
       - QueryUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-query-user-services
-      Architectures: ["x86_64"]
+      Architectures: ["arm64"]
       CodeUri: ../lambda/query-user-services/
       Events:
         DynamoStream:
@@ -530,7 +530,7 @@ Resources:
       - FormatUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-format-user-services
-      Architectures: ["x86_64"]
+      Architectures: ["arm64"]
       CodeUri: ../lambda/format-user-services/
       Events:
         UserServicesToFormatQueue:
@@ -676,7 +676,7 @@ Resources:
       - WriteUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-write-user-services
-      Architectures: ["x86_64"]
+      Architectures: ["arm64"]
       CodeUri: ../lambda/write-user-services/
       Events:
         UserServicesToWriteQueue:
@@ -875,7 +875,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-user-services
-      Architectures: ["x86_64"]
+      Architectures: ["arm64"]
       CodeUri: ../lambda/delete-user-services/
       DeadLetterQueue:
         Type: SQS
@@ -1106,7 +1106,7 @@ Resources:
           - Effect: Allow
             Principal:
               Service: sns.amazonaws.com
-            Action: 
+            Action:
               - kms:Decrypt
               - kms:GenerateDataKey
             Resource:


### PR DESCRIPTION
- Update the processor Architecture to `arm64` .
- Link to [ADR](https://github.com/alphagov/digital-identity-architecture/pull/365/files) 
- Tested this on dev .
- Check weather the Cloud Formation [template](https://eu-west-2.console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/template?filteringText=backend&filteringStatus=active&viewNested=true&stackId=arn%3Aaws%3Acloudformation%3Aeu-west-2%3A985326104449%3Astack%2Faccount-mgmt-backend%2F69df82c0-b1eb-11ed-8e82-0233824c9288) is updated with the relevant changes.
**Steps to Test** 

**Step 1** : Make sure this branch is deployed on dev . Since dev is on control tower follow [steps](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3364586065/SSO+with+IAM+Identity+Centre+and+Control+Tower#3.-SSO-Access-to-a-Control-Tower-Account-via-CLI) to log in using CLI 
**Step 2** : Deploy branch
`cd infrastructure` 
`sam build && gds aws di-account-dev -- sam deploy` 
**Step 3** : Send a message on the TXMA DummyInput SQS queue 
`gds aws di-account-dev -- aws sqs send-message \
  --queue-url https://sqs.eu-west-2.amazonaws.com/985326104449/account-mgmt-backend-TxMAInputDummyQueue-IsIIlhfkijBS \
  --message-body '{"event_name":"event-name","timestamp":1666169856,"client_id":"gov-uk","component_id":"component-id","user":{"user_id":"simple_test_example"}}'`
**Step 4** : Make sure there are no errors in the logs and both the dynamo tables are updated with the correct user_id and client_id 
<img width="665" alt="Screenshot 2023-03-10 at 12 46 37" src="https://user-images.githubusercontent.com/17740808/224319798-66944155-80e0-4b25-bea0-3a983642827f.png">

<img width="673" alt="Screenshot 2023-03-10 at 12 46 56" src="https://user-images.githubusercontent.com/17740808/224319774-25498fa8-db74-46a3-96e9-8b103fb12622.png">
