### PR TITLE
GUA-705 Update Log Group Name for Delete User Services

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -960,7 +960,7 @@ Resources:
   DeleteUserServicesFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "${AWS::StackName}-delete-user-service-log-group"
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-delete-user-services"
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 


### PR DESCRIPTION
- Rename the LogGroup Name to be consistent with the other lambas. 
Note: I had to delete the old Log group otherwise the deploy fails with error 
```
Resource handler

DeleteUserServicesFunctionLogGroup   
returned message:
 "Resource of type 'AWS::Logs::LogGroup'
with identifier '{"/properties/LogGroupName" :"/aws/lambda/dev-account-mgmt-backend-delete-user-services"}' already exists."(RequestToken: aa8edfeb-ad5d-27f1-54bf-93f839c6450c, HandlerErrorCode: AlreadyExists)
```

https://stackoverflow.com/questions/56137460/an-error-occurred-loggroup-resource-name-already-exists-while-trying-to-d
