### PR TITLE
BAU: Fix validator tests

### DIFF
--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -32,6 +32,7 @@ describe("writeRawTxmaEvent", () => {
     jest.spyOn(Date, "now").mockRestore();
     jest.spyOn(crypto, "randomUUID").mockRestore();
   });
+
   test("writes raw events to DynamoDB", async () => {
     await writeRawTxmaEvent(makeTxmaEvent());
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
@@ -46,6 +47,7 @@ describe("writeRawTxmaEvent", () => {
     });
   });
 });
+
 describe("validateUser", () => {
   test("throws error when user is is missing", () => {
     const inValidUser = JSON.parse(JSON.stringify({}));
@@ -59,6 +61,7 @@ describe("validateTxmaEventBody", () => {
   test("doesn't throw an error with valid txma data", () => {
     expect(validateTxmaEventBody(makeTxmaEvent())).toBe(undefined);
   });
+
   test("throws error when client_id is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
@@ -73,6 +76,7 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
   });
+
   test("throws error when timestamp is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
@@ -101,6 +105,7 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
   });
+
   test(" throws error when user is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
@@ -115,6 +120,7 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
   });
+
   test("throws error when user_id is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
@@ -172,14 +178,17 @@ describe("handler error handling", () => {
     consoleErrorMock = jest.spyOn(global.console, "error").mockImplementation();
     dynamoMock.rejectsOnce("mock error");
   });
+
   afterEach(() => {
     consoleErrorMock.mockRestore();
     jest.clearAllMocks();
   });
+
   test("logs the error message", async () => {
     await handler(TEST_SQS_EVENT);
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
   });
+
   test("sends the event to the dead letter queue", async () => {
     await handler(TEST_SQS_EVENT);
     expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -102,7 +102,7 @@ describe("validateTxmaEventBody", () => {
     );
   });
 
-  test(" throws error when user is missing", () => {
+  test("throws error when user is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
       user: undefined,

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -53,7 +53,9 @@ describe("validateUser", () => {
     const inValidUser = JSON.parse(JSON.stringify({}));
     expect(() => {
       validateUser(inValidUser);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not find User ${JSON.stringify(inValidUser)}`)
+    );
   });
 });
 
@@ -70,7 +72,9 @@ describe("validateTxmaEventBody", () => {
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not validate UserServices ${JSON.stringify(txmaEvent)}`)
+    );
   });
 
   test("throws error when timestamp is missing", () => {
@@ -81,7 +85,9 @@ describe("validateTxmaEventBody", () => {
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not validate UserServices ${JSON.stringify(txmaEvent)}`)
+    );
   });
   test("throws error when event name is missing", () => {
     const invalidTxmaEvent = {
@@ -91,7 +97,9 @@ describe("validateTxmaEventBody", () => {
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not validate UserServices ${JSON.stringify(txmaEvent)}`)
+    );
   });
 
   test(" throws error when user is missing", () => {
@@ -102,7 +110,9 @@ describe("validateTxmaEventBody", () => {
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not validate UserServices ${JSON.stringify(txmaEvent)}`)
+    );
   });
 
   test("throws error when user_id is missing", () => {
@@ -113,7 +123,9 @@ describe("validateTxmaEventBody", () => {
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
+    }).toThrowError(
+      new Error(`Could not find User ${JSON.stringify(txmaEvent.user)}`)
+    );
   });
 });
 

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -67,11 +67,7 @@ describe("validateTxmaEventBody", () => {
       ...makeTxmaEvent(),
       clientId: undefined,
     };
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [invalidTxmaEvent],
-      })
-    );
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
@@ -82,11 +78,7 @@ describe("validateTxmaEventBody", () => {
       ...makeTxmaEvent(),
       timestamp: undefined,
     };
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [invalidTxmaEvent],
-      })
-    );
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
@@ -96,11 +88,7 @@ describe("validateTxmaEventBody", () => {
       ...makeTxmaEvent(),
       event_name: undefined,
     };
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [invalidTxmaEvent],
-      })
-    );
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
@@ -111,11 +99,7 @@ describe("validateTxmaEventBody", () => {
       ...makeTxmaEvent(),
       user: undefined,
     };
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [invalidTxmaEvent],
-      })
-    );
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();
@@ -126,11 +110,7 @@ describe("validateTxmaEventBody", () => {
       ...makeTxmaEvent(),
       user: {},
     };
-    const txmaEvent = JSON.parse(
-      JSON.stringify({
-        services: [invalidTxmaEvent],
-      })
-    );
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
       validateTxmaEventBody(txmaEvent);
     }).toThrowError();

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -65,7 +65,7 @@ describe("validateTxmaEventBody", () => {
   test("throws error when client_id is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),
-      clientId: undefined,
+      client_id: undefined,
     };
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {


### PR DESCRIPTION
Tidies up the Validator tests for the Raw Events store lambda.
We'll likely need to look at similar improvements to the other lambdas.

In this case tests were passing because the user validator check was throwing, when we'd hoped it was the txma body check.