### PR TITLE
GUA-746: Add Session ID to raw event store

### DIFF
--- a/lambda/save-raw-events/models.ts
+++ b/lambda/save-raw-events/models.ts
@@ -1,5 +1,6 @@
 type UrnFdnSub = string;
 type ClientId = string;
+type SessionId = string;
 
 export interface TxmaEvent {
   event_id: string;
@@ -13,4 +14,5 @@ export interface TxmaEvent {
 export interface UserData {
   user_id: UrnFdnSub;
   govuk_signin_journey_id: string;
+  session_id: SessionId;
 }

--- a/lambda/save-raw-events/save-raw-events.ts
+++ b/lambda/save-raw-events/save-raw-events.ts
@@ -37,7 +37,7 @@ export const getTTLDate = (): number => {
 };
 
 export const validateUser = (user: UserData): void => {
-  if (!user.user_id) {
+  if (!user.user_id || !user.session_id) {
     throw new Error(`Could not find User ${JSON.stringify(user)}`);
   }
 };

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -10,7 +10,7 @@ import {
   writeRawTxmaEvent,
   validateUser,
 } from "../save-raw-events";
-import { TEST_SQS_EVENT, makeTxmaEvent } from "./test-helpers";
+import { TEST_SQS_EVENT, makeTxmaEvent, user } from "./test-helpers";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 const sqsMock = mockClient(SQSClient);
@@ -51,6 +51,48 @@ describe("writeRawTxmaEvent", () => {
 describe("validateUser", () => {
   test("throws error when user is is missing", () => {
     const inValidUser = JSON.parse(JSON.stringify({}));
+    expect(() => {
+      validateUser(inValidUser);
+    }).toThrowError(
+      new Error(`Could not find User ${JSON.stringify(inValidUser)}`)
+    );
+  });
+
+  test("throws error when user_id key is missing", () => {
+    const inValidUser = JSON.parse(
+      JSON.stringify({
+        ...user,
+        user_id: undefined,
+      })
+    );
+    expect(() => {
+      validateUser(inValidUser);
+    }).toThrowError(
+      new Error(`Could not find User ${JSON.stringify(inValidUser)}`)
+    );
+  });
+
+  test("throws error when session_id key is missing", () => {
+    const inValidUser = JSON.parse(
+      JSON.stringify({
+        ...user,
+        session_id: undefined,
+      })
+    );
+    expect(() => {
+      validateUser(inValidUser);
+    }).toThrowError(
+      new Error(`Could not find User ${JSON.stringify(inValidUser)}`)
+    );
+  });
+
+  test("throws error when session_id value is null", () => {
+    const inValidUser = JSON.parse(
+      JSON.stringify({
+        ...user,
+        session_id: null,
+      })
+    );
     expect(() => {
       validateUser(inValidUser);
     }).toThrowError(

--- a/lambda/save-raw-events/tests/test-helpers.ts
+++ b/lambda/save-raw-events/tests/test-helpers.ts
@@ -3,12 +3,14 @@ import { TxmaEvent, UserData } from "../models";
 
 const userId = "user_id";
 const eventId = "ab12345a-a12b-3ced-ef12-12a3b4cd5678";
+const sessionId = "Upt1k+cYtXSwadQHvxsfDg==";
 const eventName = "AUTH_AUTH_CODE_ISSUED";
 const clientId = "client_id";
 
-const user: UserData = {
+export const user: UserData = {
   user_id: userId,
   govuk_signin_journey_id: "govuk_signin_journey_id",
+  session_id: sessionId,
 };
 
 export const date = new Date();


### PR DESCRIPTION
This is part of extending the raw events store to handle events we will need to render the activity log. We'll want to use the AUTH_AUTH_CODE_ISSUED event, but be able to aggregate them by the earliest event grouped by a session_id.