### PR TITLE
GUA-746 - Remove govuk journey

### DIFF
--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -16,7 +16,6 @@ export interface Service {
 export interface TxmaEvent {
   event_id: string;
   timestamp: number;
-  timestamp_formatted: string;
   event_name: string;
   client_id: ClientId;
   user: UserData;

--- a/lambda/format-user-services/models.ts
+++ b/lambda/format-user-services/models.ts
@@ -24,7 +24,6 @@ export interface TxmaEvent {
 
 export interface UserData {
   user_id: UrnFdnSub;
-  govuk_signin_journey_id: string;
 }
 
 export interface UserServices {

--- a/lambda/format-user-services/tests/test-helpers.ts
+++ b/lambda/format-user-services/tests/test-helpers.ts
@@ -47,7 +47,6 @@ export const makeTxmaEvent = (clientId: string, userId: string): TxmaEvent => ({
   event_name: "event_1",
   event_id: "event_id",
   timestamp: 1670850655485,
-  timestamp_formatted: "2022-12-12T13:10:55.485Z",
   client_id: clientId,
   user: {
     user_id: userId,

--- a/lambda/format-user-services/tests/test-helpers.ts
+++ b/lambda/format-user-services/tests/test-helpers.ts
@@ -51,7 +51,6 @@ export const makeTxmaEvent = (clientId: string, userId: string): TxmaEvent => ({
   client_id: clientId,
   user: {
     user_id: userId,
-    govuk_signin_journey_id: "abc123",
   },
 });
 

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -9,7 +9,6 @@ export interface UserServices {
 export interface TxmaEvent {
   event_id: string;
   timestamp: number;
-  timestamp_formatted: string;
   event_name: string;
   client_id: ClientId;
   user: UserData;

--- a/lambda/query-user-services/models.ts
+++ b/lambda/query-user-services/models.ts
@@ -23,7 +23,6 @@ export interface Service {
 
 export interface UserData {
   user_id: UrnFdnSub;
-  govuk_signin_journey_id: string;
 }
 
 export interface UserRecordEvent {

--- a/lambda/query-user-services/tests/test-helpers.ts
+++ b/lambda/query-user-services/tests/test-helpers.ts
@@ -8,7 +8,6 @@ export const tableName = "TableName";
 export const messageId = "MyMessageId";
 export const queueUrl = "http://my_queue_url";
 const timestamp = date.valueOf();
-const timestampFormatted = date.toISOString();
 
 const user: UserData = {
   user_id: userId,
@@ -18,7 +17,6 @@ export const TEST_TXMA_EVENT: TxmaEvent = {
   event_id: "event_id",
   event_name: "event_name",
   timestamp,
-  timestamp_formatted: timestampFormatted,
   client_id: clientId,
   user,
 };
@@ -44,9 +42,6 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
           },
           timestamp: {
             N: `${timestamp}`,
-          },
-          timestamp_formatted: {
-            S: timestampFormatted,
           },
           client_id: {
             S: clientId,

--- a/lambda/query-user-services/tests/test-helpers.ts
+++ b/lambda/query-user-services/tests/test-helpers.ts
@@ -9,11 +9,9 @@ export const messageId = "MyMessageId";
 export const queueUrl = "http://my_queue_url";
 const timestamp = date.valueOf();
 const timestampFormatted = date.toISOString();
-const govukSigninJourneyId = "abc123";
 
 const user: UserData = {
   user_id: userId,
-  govuk_signin_journey_id: govukSigninJourneyId,
 };
 
 export const TEST_TXMA_EVENT: TxmaEvent = {
@@ -57,9 +55,6 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
             M: {
               user_id: {
                 S: userId,
-              },
-              govuk_signin_journey_id: {
-                S: govukSigninJourneyId,
               },
             },
           },

--- a/lambda/save-raw-events/models.ts
+++ b/lambda/save-raw-events/models.ts
@@ -5,7 +5,6 @@ type SessionId = string;
 export interface TxmaEvent {
   event_id: string;
   timestamp: number;
-  timestamp_formatted: string;
   event_name: string;
   client_id: ClientId;
   user: UserData;

--- a/lambda/save-raw-events/models.ts
+++ b/lambda/save-raw-events/models.ts
@@ -13,6 +13,5 @@ export interface TxmaEvent {
 
 export interface UserData {
   user_id: UrnFdnSub;
-  govuk_signin_journey_id: string;
   session_id: SessionId;
 }

--- a/lambda/save-raw-events/tests/test-helpers.ts
+++ b/lambda/save-raw-events/tests/test-helpers.ts
@@ -9,7 +9,6 @@ const clientId = "client_id";
 
 export const user: UserData = {
   user_id: userId,
-  govuk_signin_journey_id: "govuk_signin_journey_id",
   session_id: sessionId,
 };
 

--- a/lambda/save-raw-events/tests/test-helpers.ts
+++ b/lambda/save-raw-events/tests/test-helpers.ts
@@ -18,7 +18,6 @@ export const makeTxmaEvent = (): TxmaEvent => ({
   event_name: eventName,
   event_id: eventId,
   timestamp: date.valueOf(),
-  timestamp_formatted: date.toISOString(),
   client_id: clientId,
   user,
 });


### PR DESCRIPTION
Dependent on: https://github.com/alphagov/di-account-management-backend/pull/90

Removing this for two major reasons.

1. We're not really using it, and the principle of data minimisation is
   a good one. I'd rather not be storing things unless I have a good use
   or reasonable propect that we'll need it in future.

2. We currently support AUTH_AUTH_CODE_ISSUED, and are looking to add a
   second event shortly in AUTH_IPV_AUTHORISATION_REQUESTED event.
   According to the TxMA event spreadsheet
   AUTH_IPV_AUTHORISATION_REQUESTED does not currently support
   govuk_journy_id.

We want to try and keep these consistent so that we can validate for a
single TxMA Event shaped input, so I'll be changing these up in self
service to make them consistent.