### PR TITLE
GUA: 746: Ensure only auth auth code for service cards

### DIFF
--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -90,7 +90,7 @@ describe("validateTxmaEventBody", () => {
         services: [
           {
             timestamp: new Date().toISOString,
-            event_name: "event_name",
+            event_name: "AUTH_AUTH_CODE_ISSUED",
             user: {
               user_id: userId,
             },
@@ -108,7 +108,7 @@ describe("validateTxmaEventBody", () => {
         services: [
           {
             client_id: clientId,
-            event_name: "event_name",
+            event_name: "AUTH_AUTH_CODE_ISSUED",
             user: {
               user_id: userId,
             },
@@ -145,7 +145,7 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: clientId,
             timestamp: new Date().toISOString,
-            event_name: "event_name",
+            event_name: "AUTH_AUTH_CODE_ISSUED",
           },
         ],
       })
@@ -161,7 +161,7 @@ describe("validateTxmaEventBody", () => {
           {
             client_id: clientId,
             timestamp: new Date().toISOString,
-            event_name: "event_name",
+            event_name: "AUTH_AUTH_CODE_ISSUED",
             user: {},
           },
         ],

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -223,7 +223,11 @@ describe("handler", () => {
     await handler(TEST_DYNAMO_STREAM_EVENT);
     expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(2);
     expect(dynamoMock.commandCalls(GetCommand).length).toEqual(2);
-    expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
+    expect(sqsMock).toHaveReceivedNthCommandWith(1, SendMessageCommand, {
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(userRecordEvents),
+    });
+    expect(sqsMock).toHaveReceivedNthCommandWith(2, SendMessageCommand, {
       QueueUrl: queueUrl,
       MessageBody: JSON.stringify(userRecordEvents),
     });

--- a/lambda/query-user-services/tests/query-user-services.test.ts
+++ b/lambda/query-user-services/tests/query-user-services.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   TEST_TXMA_EVENT,
   TEST_DYNAMO_STREAM_EVENT,
+  MUCKY_DYNAMODB_STREAM_EVENT,
   tableName,
   messageId,
   queueUrl,
@@ -228,6 +229,16 @@ describe("handler", () => {
       MessageBody: JSON.stringify(userRecordEvents),
     });
     expect(sqsMock).toHaveReceivedNthCommandWith(2, SendMessageCommand, {
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(userRecordEvents),
+    });
+  });
+
+  test("Ignores any non-AUTH_AUTH_CODE_ISSUED event", async () => {
+    await handler(MUCKY_DYNAMODB_STREAM_EVENT);
+    expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+    expect(dynamoMock.commandCalls(GetCommand).length).toEqual(1);
+    expect(sqsMock).toHaveReceivedNthCommandWith(1, SendMessageCommand, {
       QueueUrl: queueUrl,
       MessageBody: JSON.stringify(userRecordEvents),
     });

--- a/lambda/query-user-services/tests/test-helpers.ts
+++ b/lambda/query-user-services/tests/test-helpers.ts
@@ -25,7 +25,9 @@ export const TEST_TXMA_EVENT: TxmaEvent = {
   user,
 };
 
-const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
+const generateDynamoSteamRecord = (
+  txmaEventName = "AUTH_AUTH_CODE_ISSUED"
+): DynamoDBRecord => ({
   eventID: "1234567",
   eventName: "INSERT",
   dynamodb: {
@@ -42,7 +44,7 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
             S: "event_id",
           },
           event_name: {
-            S: "event_name",
+            S: `${txmaEventName}`,
           },
           timestamp: {
             N: `${timestamp}`,
@@ -67,8 +69,11 @@ const TEST_DYNAMO_STREAM_RECORD: DynamoDBRecord = {
       },
     },
   },
-};
+});
 
 export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [TEST_DYNAMO_STREAM_RECORD, TEST_DYNAMO_STREAM_RECORD],
+  Records: [
+    generateDynamoSteamRecord("event_name"),
+    generateDynamoSteamRecord("event_name"),
+  ],
 };

--- a/lambda/query-user-services/tests/test-helpers.ts
+++ b/lambda/query-user-services/tests/test-helpers.ts
@@ -16,14 +16,16 @@ const user: UserData = {
   govuk_signin_journey_id: govukSigninJourneyId,
 };
 
-export const TEST_TXMA_EVENT: TxmaEvent = {
+const generateTestTxmaEvent = (
+  txmaEventName = "AUTH_AUTH_CODE_ISSUED"
+): TxmaEvent => ({
   event_id: "event_id",
-  event_name: "event_name",
+  event_name: `${txmaEventName}`,
   timestamp,
   timestamp_formatted: timestampFormatted,
   client_id: clientId,
   user,
-};
+});
 
 const generateDynamoSteamRecord = (
   txmaEventName = "AUTH_AUTH_CODE_ISSUED"
@@ -72,8 +74,7 @@ const generateDynamoSteamRecord = (
 });
 
 export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [
-    generateDynamoSteamRecord("event_name"),
-    generateDynamoSteamRecord("event_name"),
-  ],
+  Records: [generateDynamoSteamRecord(), generateDynamoSteamRecord()],
 };
+
+export const TEST_TXMA_EVENT: TxmaEvent = generateTestTxmaEvent();

--- a/lambda/query-user-services/tests/test-helpers.ts
+++ b/lambda/query-user-services/tests/test-helpers.ts
@@ -77,4 +77,12 @@ export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
   Records: [generateDynamoSteamRecord(), generateDynamoSteamRecord()],
 };
 
+export const MUCKY_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {
+  Records: [
+    generateDynamoSteamRecord("AUTH_IPV_AUTHORISATION_REQUESTED"),
+    generateDynamoSteamRecord(),
+    generateDynamoSteamRecord("AUTH_OTHER_RANDOM_EVENT"),
+  ],
+};
+
 export const TEST_TXMA_EVENT: TxmaEvent = generateTestTxmaEvent();


### PR DESCRIPTION
Block off the query pipeline to any event other than AUTH_AUTH_CODE_ISSUED at a time where we're expanding the raw event store.