### PR TITLE
GUA-748 : Update table name after change of sort key type

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -11,7 +11,7 @@ Parameters:
     Default: raw_events
   ActivityLogStoreTableName:
     Type: String
-    Default: activity_log
+    Default: activity_logs
   DummyEventStoreTableName:
     Type: String
     Default: dummy_events


### PR DESCRIPTION
When deployed we were getting an error : https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/301577035144/projects/Deploy-account-mgmt-backend-pipeline/build/Deploy-account-mgmt-backend-pipeline%3A5d68cd1d-f816-4298-8f21-0fd6158bdb7e/?region=eu-west-2


`CloudFormation cannot update a stack when a custom-named resource requires replacing.Rename activity_log and update the stack again.`

Renaming the table name as per : https://repost.aws/knowledge-center/cloudformation-custom-name

