### PR TITLE
GUA-872: Add spec for Account Management API Stub

### DIFF
--- a/docs/stubs/account-management-api/openapi.yaml
+++ b/docs/stubs/account-management-api/openapi.yaml
@@ -1,0 +1,134 @@
+openapi: 3.0.3
+info:
+  title: Account management API Stub
+  description: |-
+    API specification for a stub of the Account Management API which always 
+    returns a 204 response code on appropriate routes.
+    
+  version: 1.0.11
+paths:
+  /delete-account:
+    post:
+      description: Delete a user's account
+      operationId: deleteAccount
+      requestBody:
+        description: Delete a user's account
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DeleteAccount'
+        required: true
+      responses:
+        '204':
+          description: Successful operation
+          
+  /send-otp-notification:
+    post:
+      description: Send an OTP notification
+      operationId: sendOtpNotification
+      requestBody:
+        description: Send an OTP notification
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/SendOtpNotification'
+        required: true
+      responses:
+        '204':
+          description: Successful operation
+          
+  /update-password:
+    post:
+      description: Update a user's password
+      operationId: updatePassword
+      requestBody:
+        description: Update a user's password
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UpdatePassword'
+        required: true
+      responses:
+        '204':
+          description: Successful operation
+          
+  /update-email:
+    post:
+      description: Update a user's email
+      operationId: updateEmail
+      requestBody:
+        description: Update a user's email
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UpdateEmail'
+        required: true
+      responses:
+        '204':
+          description: Successful operation
+          
+  /update-phone-number:
+    post:
+      description: Update a user's phone number
+      operationId: updatePhoneNumber
+      requestBody:
+        description: Update a user's phone number
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UpdatePhoneNumber'
+        required: true
+      responses:
+        '204':
+          description: Successful operation
+          
+components:
+  schemas:
+    DeleteAccount:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john@email.com
+    SendOtpNotification:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john@email.com
+        notificationType:
+          type: string
+          example: 'EMAIL'
+    UpdatePassword:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john@email.com
+        newPassword:
+          type: string
+          example: '12345'
+    UpdateEmail:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john@email.com
+        newEmail:
+          type: string
+          example: john@email.com
+        otp:
+          type: string
+          example: '123456'
+    UpdatePhoneNumber:
+      type: object
+      properties:
+        email:
+          type: string
+          example: john@email.com
+        newPhoneNumber:
+          type: string
+          example: '12345'
+        otp:
+          type: string
+          example: '123456'


### PR DESCRIPTION
This OpenAPI specification defines the routes, requests and responses the stub will need to support.

It's a very simple stub with only 5 routes and it always returns an empty response with status 204, but it's worth documenting properly in case we need to make changes in the future. The schemas in particular are overkill since we don't really care about the request but it might save us some digging around later on. 

I've chosen to put this in the backend repo because the stub will effectively be a backend service and that's where I'm expecting us to put the code / Cloudformation for it as well. If we end up putting the stub code in the frontend repo then we should move this documentation there as well.