### PR TITLE
BAU: Reduce raw events TTL to 14 days

### DIFF
--- a/lambda/save-raw-events/save-raw-events.ts
+++ b/lambda/save-raw-events/save-raw-events.ts
@@ -32,7 +32,7 @@ export const getEventId = (): string => {
 export const getTTLDate = (): number => {
   const SECONDS_IN_AN_DAY = 60 * 60 * 24;
   const secondsSinceEpoch = Math.round(Date.now() / 1000);
-  const expirationTime = secondsSinceEpoch + 90 * SECONDS_IN_AN_DAY;
+  const expirationTime = secondsSinceEpoch + 14 * SECONDS_IN_AN_DAY;
   return expirationTime;
 };
 

--- a/lambda/save-raw-events/tests/save-raw-events.test.ts
+++ b/lambda/save-raw-events/tests/save-raw-events.test.ts
@@ -42,7 +42,7 @@ describe("writeRawTxmaEvent", () => {
         id: UUID,
         timestamp: TIMESTAMP,
         event: makeTxmaEvent(),
-        remove_at: 9444506,
+        remove_at: 2878106,
       },
     });
   });
@@ -248,7 +248,7 @@ describe("handler", () => {
         id: UUID,
         timestamp: TIMESTAMP,
         event: makeTxmaEvent(),
-        remove_at: 9444506,
+        remove_at: 2878106,
       },
     });
   });


### PR DESCRIPTION
This is one of the mitigations from our threat modelling session to reduce risk of data exposure in the raw event store. The system has been happily running for several months now and we're not going to need 90 days data to back fill anything.

14 days is still enough time for us to do any event replays if we have an outage over a period like Christmas where we may have several team members on leave.