### PR TITLE
GUA-874: Deploy Account Management stub API to build

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -68,6 +68,8 @@ Conditions:
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
 
+  UseStubServices: !Equals [!Ref Environment, build]
+
 Globals:
   Function:
     CodeSigningConfigArn: !If
@@ -1542,7 +1544,6 @@ Resources:
         - !Ref AlarmNotificationTopic
       ActionsEnabled: true
 
-
   ###################
   # Write Activity Log
   ###################
@@ -1673,7 +1674,11 @@ Resources:
       AlarmName:
         !Join [
           "-",
-          [!Ref AWS::StackName, !Ref Environment, WriteActivityLogDeadLetterQueueAlarm],
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            WriteActivityLogDeadLetterQueueAlarm,
+          ],
         ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
@@ -1819,7 +1824,11 @@ Resources:
       AlarmName:
         !Join [
           "-",
-          [!Ref AWS::StackName, !Ref Environment, FormatActivityLogDeadLetterQueueAlarm],
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            FormatActivityLogDeadLetterQueueAlarm,
+          ],
         ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
@@ -2289,3 +2298,104 @@ Resources:
       Name: !Sub "/${AWS::StackName}/KMS/SnsKmsKey/ID"
       Type: String
       Value: !Ref SnsKmsKey
+
+  #######################
+  # Stubs
+  #######################
+
+  AccountManagementStubFunction:
+    Condition: UseStubServices
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - AccountManagementStubFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-account-management-api-stub
+      Architectures: ["arm64"]
+      CodeUri: ../lambda/stubs/account-management-api/
+      Handler: account-management-api-stub.handler
+      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
+      PackageType: Zip
+      MemorySize: 128
+      ReservedConcurrentExecutions: 5
+      Runtime: nodejs18.x
+      Role: !GetAtt AccountManagementStubFunctionRole.Arn
+      Timeout: 5
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - account-management-api-stub.ts
+
+  AccountManagementStubFunctionRole:
+    Condition: UseStubServices
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  AccountManagementStubApi:
+    Condition: UseStubServices
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: AccountManagementStubApi
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowOrigins:
+          - "*"
+        AllowMethods:
+          - GET
+          - HEAD
+          - OPTIONS
+          - POST
+      Target: !GetAtt AccountManagementStubFunction.Arn
+
+  AccountManagementStubApiPermission:
+    Condition: UseStubServices
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName: !Ref AccountManagementStubFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${AccountManagementStubApi}/*"
+
+  AccountManagementStubFunctionLogGroup:
+    Condition: UseStubServices
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-account-management-api-stub"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  AccountManagementStubApiEndpoint:
+    Condition: UseStubServices
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The API Gateway endpoint for the Account Management stub
+      Name: !Sub "/${AWS::StackName}/Stub/AccountManagement/Endpoint"
+      Type: String
+      Value: !GetAtt AccountManagementStubApi.ApiEndpoint


### PR DESCRIPTION
This adds a new condition to use stubbed services in case we want to use them in dev in the future too.

This setup is broadly the same as the example stack I attached to PR #118 where I added the lambda. The only differences are the logging and other production-ready stuff like the permissions boundary and the VPCs.

I've intentionally not put a dead letter queue on this lambda because it's a standalone thing returning a static payload. We'll have enough info in the logs to debug any problems and it doesn't matter if we 'lose' the event data that triggered an error.

The API endpoint is saved to a parameter store value. I'll reference this in the frontend stack template to set the `AM_API_BASE_URL` environment variable

This change is deployed to dev at the moment. You can test the API with curl: 

```
~  $ curl -i https://i6wi3m1vvi.execute-api.eu-west-2.amazonaws.com/delete-account
HTTP/2 204
date: Tue, 04 Jul 2023 14:49:33 GMT
apigw-requestid: HiyrkgUyrPEEQ0A=
```
