### PR TITLE
OLH-1006: Save the event ID in the activity log

### DIFF
--- a/lambda/format-activity-log/format-activity-log.ts
+++ b/lambda/format-activity-log/format-activity-log.ts
@@ -13,6 +13,13 @@ import {
   UserData,
 } from "./models";
 
+const activityFromTxmaEvent = (txmaEvent: TxmaEvent): Activity => ({
+  type: txmaEvent.event_name,
+  client_id: txmaEvent.client_id,
+  timestamp: txmaEvent.timestamp,
+  event_id: txmaEvent.event_id,
+});
+
 const createNewActivityLogEntryFromTxmaEvent = (
   txmaEvent: TxmaEvent
 ): ActivityLogEntry => ({
@@ -20,20 +27,8 @@ const createNewActivityLogEntryFromTxmaEvent = (
   session_id: txmaEvent.user.session_id,
   user_id: txmaEvent.user.user_id,
   timestamp: txmaEvent.timestamp,
-  activities: [
-    {
-      type: txmaEvent.event_name,
-      client_id: txmaEvent.client_id,
-      timestamp: txmaEvent.timestamp,
-    },
-  ],
+  activities: [activityFromTxmaEvent(txmaEvent)],
   truncated: false,
-});
-
-const activityFromTxmaEvent = (txmaEvent: TxmaEvent): Activity => ({
-  type: txmaEvent.event_name,
-  client_id: txmaEvent.client_id,
-  timestamp: txmaEvent.timestamp,
 });
 
 export const validateUser = (user: UserData): void => {
@@ -47,7 +42,8 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
     txmaEvent.client_id !== undefined &&
-    txmaEvent.user !== undefined
+    txmaEvent.user !== undefined &&
+    txmaEvent.event_id !== undefined
   ) {
     validateUser(txmaEvent.user);
   } else {

--- a/lambda/format-activity-log/models.ts
+++ b/lambda/format-activity-log/models.ts
@@ -17,6 +17,7 @@ export interface Activity {
   type: string;
   client_id: string;
   timestamp: number;
+  event_id: string;
 }
 
 export interface ActivityLogEntry {

--- a/lambda/format-activity-log/tests/test-helper.ts
+++ b/lambda/format-activity-log/tests/test-helper.ts
@@ -35,9 +35,10 @@ const MUTABLE_TXMA_EVENT: TxmaEvent = {
 };
 
 export const activity: Activity = {
+  type: eventType,
   client_id: clientId,
   timestamp,
-  type: eventType,
+  event_id: txmaEventId,
 };
 
 export const MUTABLE_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
@@ -45,13 +46,7 @@ export const MUTABLE_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
   session_id: sessionId,
   user_id: userId,
   timestamp,
-  activities: [
-    {
-      type: eventType,
-      client_id: clientId,
-      timestamp,
-    },
-  ],
+  activities: [activity],
   truncated,
 };
 
@@ -81,15 +76,12 @@ export const TEST_USER_ACTIVITY_SECOND_TXMA_EVENT: UserActivityLog = {
 };
 
 const twoActivities: Activity[] = [
-  {
-    client_id: clientId,
-    timestamp,
-    type: eventType,
-  },
+  activity,
   {
     client_id: clientId,
     timestamp,
     type: secondEventType,
+    event_id: txmaEventId,
   },
 ];
 export const TEST_ACTIVITY_LOG_ENTRY_WITH_TWO_ACTIVITIES: ActivityLogEntry = {

--- a/lambda/query-activity-log/models.ts
+++ b/lambda/query-activity-log/models.ts
@@ -17,6 +17,7 @@ export interface Activity {
   type: string;
   client_id: string;
   timestamp: number;
+  event_id: string;
 }
 
 export interface ActivityLogEntry {

--- a/lambda/query-activity-log/query-activity-log.ts
+++ b/lambda/query-activity-log/query-activity-log.ts
@@ -56,7 +56,8 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
     txmaEvent.client_id !== undefined &&
-    txmaEvent.user !== undefined
+    txmaEvent.user !== undefined &&
+    txmaEvent.event_id !== undefined
   ) {
     validateUser(txmaEvent.user);
   } else {

--- a/lambda/query-activity-log/tests/query-activity-log.test.ts
+++ b/lambda/query-activity-log/tests/query-activity-log.test.ts
@@ -15,6 +15,7 @@ import {
   TEST_DYNAMO_STREAM_EVENT,
   TEST_TXMA_EVENT,
   clientId,
+  eventId,
   eventType,
   messageId,
   queueUrl,
@@ -33,6 +34,7 @@ const activityList: Activity[] = [
     type: "service_visited",
     client_id: clientId,
     timestamp,
+    event_id: eventId,
   },
 ];
 

--- a/lambda/query-activity-log/tests/test-helpers.ts
+++ b/lambda/query-activity-log/tests/test-helpers.ts
@@ -6,6 +6,7 @@ export const randomEventType = "AUTH_OTHER_RANDOM_EVENT";
 export const userId = "user_id";
 export const sessionId = "session_id";
 export const clientId = "client_id";
+export const eventId = "event_id";
 export const date = new Date();
 export const tableName = "TableName";
 export const messageId = "MyMessageId";

--- a/lambda/write-activity-log/models.ts
+++ b/lambda/write-activity-log/models.ts
@@ -2,6 +2,7 @@ export interface Activity {
   type: string;
   client_id: string;
   timestamp: number;
+  event_id: string;
 }
 
 export interface ActivityLogEntry {

--- a/lambda/write-activity-log/tests/test-helpers.ts
+++ b/lambda/write-activity-log/tests/test-helpers.ts
@@ -1,6 +1,7 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
 import { Activity, ActivityLogEntry } from "../models";
 
+export const eventId = "event_id";
 export const eventType = "TXMA_EVENT";
 export const sessionId = "123456789";
 export const userId = "qwerty";
@@ -13,6 +14,7 @@ export const activities: Activity[] = [
     client_id: clientId,
     timestamp,
     type: eventType,
+    event_id: eventId,
   },
 ];
 

--- a/lambda/write-activity-log/write-activity-log.ts
+++ b/lambda/write-activity-log/write-activity-log.ts
@@ -20,7 +20,8 @@ const validateActivity = (activity: Activity): boolean => {
   return (
     activity.client_id !== undefined &&
     activity.timestamp !== undefined &&
-    activity.type !== undefined
+    activity.type !== undefined &&
+    activity.event_id !== undefined
   );
 };
 


### PR DESCRIPTION
I was checking that this was possible and I thought the easiest way to make sure was to do the work.

There's three commits here, changing the query, format and write lambdas in turn. It ended up being a fairly simple change but see the commit messages for more information. 

