### PR TITLE
BAU: Save successful ID check event

### DIFF
--- a/lambda/query-activity-log/models.ts
+++ b/lambda/query-activity-log/models.ts
@@ -37,4 +37,5 @@ export interface UserActivityLog {
 export const allowedTxmaEvents: Array<string> = [
   "AUTH_AUTH_CODE_ISSUED",
   "AUTH_IPV_AUTHORISATION_REQUESTED",
+  "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
 ];


### PR DESCRIPTION
We're now receiving this event from TxMA which is triggered once a user successfully completes the ID proving journey and is passed back to Auth.

We'll want to show information to users about when they proved their ID in the activity log, so add it to the list of allowed event names.

See https://github.com/alphagov/di-txma-event-self-serve/pull/231