### PR TITLE
BAU: Set timeout for Github actions

### DIFF
--- a/.github/workflows/lint-and-test-lambdas.yaml
+++ b/.github/workflows/lint-and-test-lambdas.yaml
@@ -13,6 +13,7 @@ jobs:
   lint_and_test_query_user_services:
     name: query-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/query-user-services
@@ -36,6 +37,7 @@ jobs:
   lint_and_test_format_user_services:
     name: format-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/format-user-services
@@ -59,6 +61,7 @@ jobs:
   lint_and_test_write_user_services:
     name: write-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/write-user-services
@@ -82,6 +85,7 @@ jobs:
   lint_and_test_delete_user_services:
     name: delete-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-user-services
@@ -105,6 +109,7 @@ jobs:
   lint_and_test_save_raw_events:
     name: save-raw-events
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/save-raw-events
@@ -128,6 +133,7 @@ jobs:
   lint_and_test_delete_email_subscriptions:
     name: delete-email-subscriptions
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-email-subscriptions
@@ -151,6 +157,7 @@ jobs:
   lint_and_test_query_activity_log:
     name: query_activity_log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/query-activity-log
@@ -174,6 +181,7 @@ jobs:
   lint_and_test_format_activity_log:
     name: format_activity_log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/format-activity-log
@@ -197,6 +205,7 @@ jobs:
   lint_and_test_write_activity_log:
     name: write_activity_log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/write-activity-log
@@ -220,6 +229,7 @@ jobs:
   lint_and_test_delete_activity_log:
     name: delete_activity_log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-activity-log

--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -3,7 +3,7 @@ name: CloudFormation Linter
 on:
   pull_request:
     paths:
-      - 'infrastructure/**'
+      - "infrastructure/**"
   workflow_call:
     inputs:
       gitRef:
@@ -15,6 +15,7 @@ jobs:
   lint_cloudformation:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install cfn-lint
         run: python -m pip install cfn-lint

--- a/.github/workflows/require-pinned-github-actions.yml
+++ b/.github/workflows/require-pinned-github-actions.yml
@@ -6,6 +6,7 @@ jobs:
   harden_security:
     name: Harden Security
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3

--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -10,6 +10,7 @@ jobs:
   sonarcloud_query_user_services:
     name: query-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/query-user-services
@@ -37,6 +38,7 @@ jobs:
   sonarcloud_format_user_services:
     name: format-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/format-user-services
@@ -64,6 +66,7 @@ jobs:
   sonarcloud_write_user_services:
     name: write-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/write-user-services
@@ -91,6 +94,7 @@ jobs:
   sonarcloud_delete_user_services:
     name: delete-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-user-services
@@ -119,6 +123,7 @@ jobs:
   sonarcloud_save_raw_events:
     name: save-raw-events
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/save-raw-events
@@ -147,6 +152,7 @@ jobs:
   sonarcloud_delete_email_subscriptions:
     name: delete-email-subscriptions
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-email-subscriptions
@@ -175,6 +181,7 @@ jobs:
   sonarcloud_query_activity_log:
     name: query-activity-log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/query-activity-log
@@ -203,6 +210,7 @@ jobs:
   sonarcloud_format_activity_log:
     name: format-activity-log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/format-activity-log
@@ -231,6 +239,7 @@ jobs:
   sonarcloud_delete_activity_log:
     name: delete-activity-log
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/delete-activity-log
@@ -259,6 +268,7 @@ jobs:
   sonarcloud_write_activity_log:
     name: write-user-services
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: ./lambda/write-activity-log


### PR DESCRIPTION
Set a 15 minute timeout limit for all Github actions which don't just call other workflows or already have a different limit set.

See [the action docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) for more details.

We have a shared actions runtime quota across the whole Github organisation and if we hit the quota then actions will stop running completely. This would be a very bad time, so set sensible limits so we don't get a runaway action that runs for ages.

See also https://github.com/alphagov/di-account-management-frontend/pull/993