### PR TITLE
Remove logging userData on Validation failure

### DIFF
--- a/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
+++ b/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
@@ -24,7 +24,7 @@ export const validateUserData = (userData: UserData): UserData => {
       userData.user_id !== undefined && userData.public_subject_id !== undefined
     )
   ) {
-    throw new Error(`userData is not valid : ${JSON.stringify(userData)}`);
+    throw new Error(`userData is not valid`);
   }
   return userData;
 };

--- a/lambda/delete-email-subscriptions/tests/delete-email-subscriptions.test.ts
+++ b/lambda/delete-email-subscriptions/tests/delete-email-subscriptions.test.ts
@@ -61,7 +61,7 @@ describe("validateUserData", () => {
     );
     expect(() => {
       validateUserData(userData);
-    }).toThrowError(`userData is not valid : ${JSON.stringify(userData)}`);
+    }).toThrowError(`userData is not valid`);
   });
 
   test("that it does not throw an error if the SNS message is missing the non-required attribute legacy_subject_id", () => {


### PR DESCRIPTION
## Proposed changes
Remove user_id logging on Validation Failure 
### What changed

Remove user_id logging on Validation Failure 

### Why did it change

Cannot log PII data .

