### PR TITLE
OLH-1091: Add a filter for 404 status code to not be allowed in the DLQ

### DIFF
--- a/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
+++ b/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
@@ -50,7 +50,9 @@ export const deleteEmailSubscription = async (userData: UserData) => {
   const config = getRequestConfig(GOV_ACCOUNTS_PUBLISHING_API_TOKEN);
 
   const response = await fetch(deleteUrl, config);
-  if (!response.ok) {
+  if (response.status === 404) {
+    console.log(`Received a 404 response from GOV.UK API for URL`);
+  } else if (!response.ok) {
     const message = `Unable to send DELETE request to GOV.UK API. Status code : ${response.status}`;
     throw new Error(message);
   }

--- a/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
+++ b/lambda/delete-email-subscriptions/delete-email-subscriptions.ts
@@ -51,6 +51,7 @@ export const deleteEmailSubscription = async (userData: UserData) => {
 
   const response = await fetch(deleteUrl, config);
   if (response.status === 404) {
+    // We are logging a 404 as is an appropriate reponse when the user does not have an email subscription .
     console.log(`Received a 404 response from GOV.UK API for URL`);
   } else if (!response.ok) {
     const message = `Unable to send DELETE request to GOV.UK API. Status code : ${response.status}`;


### PR DESCRIPTION
## Proposed changes

Existing functionality treats anything other than a 2XX as an error . Any error message is sent to the DLQ

### What changed
The change is to not allow a 404 request from the publishing API to be sent to the DLQ as this use case is common for users that have a service card that needs to be deleted and it is not a email subscriptions. Both the delete lambda and delete email subscriptions lambda consume from the same SNS topic.

### Why did it change

The change was needed to allow the service to log the 404 and not send it to the DLQ.

