### PR TITLE
OLH-904: Decrypt user activities before formatting

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1401,6 +1401,8 @@ Resources:
           TABLE_NAME: !Ref ActivityLogStoreTableName
           DLQ_URL: !Ref QueryActivityLogDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref ActivityLogToFormatQueue
+          ENVIRONMENT: !Ref Environment
+          ACCOUNT_ID: !Sub "${AWS::AccountId}"
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
@@ -1576,7 +1578,7 @@ Resources:
           DLQ_URL: !Ref WriteActivityLogDeadLetterQueue
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
-          BACKUP_WRAPPING_KEY_ARN: !Sub '{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}'
+          BACKUP_WRAPPING_KEY_ARN: !Sub "{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}"
           VERIFY_ACCESS_VALUE: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Storage/VerificationSecret}}"
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           ENVIRONMENT: !Ref Environment
@@ -1663,11 +1665,11 @@ Resources:
             Resource:
               - !GetAtt GeneratorKey.Arn
           - Effect: Allow
-            Action: 
+            Action:
               - kms:Encrypt
             Resource:
               - !GetAtt WrapperKey.Arn
-              - !Sub '{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}'
+              - !Sub "{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}"
 
   WriteActivityLogFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -2344,7 +2346,7 @@ Resources:
           Value: "https://github.com/alphagov/di-account-management-backend/blob/main/infrastructure/template.yaml"
         - Key: Name
           Value: !Sub "${AWS::StackName}-BackupWrapperKey"
-  
+
   WrapperKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
@@ -2360,7 +2362,7 @@ Resources:
       KeyPolicy:
         Version: "2012-10-17"
         Statement:
-          - Sid: 'Allow root account access'
+          - Sid: "Allow root account access"
             Effect: Allow
             Principal:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"

--- a/lambda/query-activity-log/decrypt-data.ts
+++ b/lambda/query-activity-log/decrypt-data.ts
@@ -1,0 +1,23 @@
+import { KmsKeyringNode, buildDecrypt } from "@aws-crypto/client-node";
+import buildKmsKeyring from "./kms-keyring-builder";
+
+const MAX_ENCRYPTED_DATA_KEY = 5;
+const DECODING = "utf8";
+
+const decryptClientConfig = { maxEncryptedDataKeys: MAX_ENCRYPTED_DATA_KEY };
+const decryptClient = buildDecrypt(decryptClientConfig);
+
+let keyring: KmsKeyringNode;
+
+async function decryptData(data: string): Promise<string> {
+  try {
+    keyring ??= await buildKmsKeyring();
+    const result = await decryptClient.decrypt(keyring, data);
+    return result.plaintext.toString(DECODING);
+  } catch (error) {
+    console.error("Failed to decrypt data.", { error });
+    throw error;
+  }
+}
+
+export default decryptData;

--- a/lambda/query-activity-log/decrypt-data.ts
+++ b/lambda/query-activity-log/decrypt-data.ts
@@ -1,4 +1,8 @@
-import { KmsKeyringNode, buildDecrypt } from "@aws-crypto/client-node";
+import {
+  EncryptionContext,
+  KmsKeyringNode,
+  buildDecrypt,
+} from "@aws-crypto/client-node";
 import buildKmsKeyring from "./kms-keyring-builder";
 
 const MAX_ENCRYPTED_DATA_KEY = 5;
@@ -9,15 +13,57 @@ const decryptClient = buildDecrypt(decryptClientConfig);
 
 let keyring: KmsKeyringNode;
 
-async function decryptData(data: string): Promise<string> {
+export function generateExpectedContext(userId: string): EncryptionContext {
+  const { AWS_REGION, ACCOUNT_ID, ENVIRONMENT } = process.env;
+  if (AWS_REGION === undefined) {
+    throw new Error("Missing AWS_REGION environment variable");
+  }
+
+  if (ACCOUNT_ID === undefined) {
+    throw new Error("Missing ACCOUNT_ID environment variable");
+  }
+
+  if (ENVIRONMENT === undefined) {
+    throw new Error("Missing ENVIRONMENT environment variable");
+  }
+
+  return {
+    origin: AWS_REGION,
+    accountId: ACCOUNT_ID,
+    stage: ENVIRONMENT,
+    userId,
+  };
+}
+
+export function validateEncryptionContext(
+  context: EncryptionContext,
+  expected: EncryptionContext
+): void {
+  if (context === undefined || Object.keys(context).length === 0) {
+    throw new Error("Encryption context is empty or undefined");
+  }
+
+  Object.keys(expected).forEach((key) => {
+    if (context[key] !== expected[key]) {
+      throw new Error(`Encryption context mismatch: ${key}`);
+    }
+  });
+}
+
+export async function decryptData(
+  data: string,
+  userId: string
+): Promise<string> {
   try {
     keyring ??= await buildKmsKeyring();
     const result = await decryptClient.decrypt(keyring, data);
+    validateEncryptionContext(
+      result.messageHeader.encryptionContext,
+      generateExpectedContext(userId)
+    );
     return result.plaintext.toString(DECODING);
   } catch (error) {
     console.error("Failed to decrypt data.", { error });
     throw error;
   }
 }
-
-export default decryptData;

--- a/lambda/query-activity-log/kms-keyring-builder.ts
+++ b/lambda/query-activity-log/kms-keyring-builder.ts
@@ -1,0 +1,50 @@
+import { KmsKeyringNode } from "@aws-crypto/client-node";
+
+export interface KMSKeyRingConfig {
+  generatorKeyId?: string;
+  keyIds: string[];
+}
+
+const AWS_ARN_PREFIX = "^arn:aws:";
+const RegexpKMSKeyArn = new RegExp(
+  `${AWS_ARN_PREFIX}kms:\\w+(?:-\\w+)+:\\d{12}:key\\/[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$`
+);
+
+let kmsKeyRingConfig: KMSKeyRingConfig;
+
+function formWrappingKeysArray(wrappingKeyArn?: string): string[] {
+  if (!wrappingKeyArn) {
+    throw new TypeError(
+      "Invalid configuration - ARN for main envelope encryption wrapping key is undefined."
+    );
+  }
+  if (!RegexpKMSKeyArn.test(wrappingKeyArn)) {
+    throw new TypeError(
+      "Invalid configuration - ARN for main envelope encryption wrapping key is invalid."
+    );
+  }
+  return [wrappingKeyArn];
+}
+
+const buildKmsKeyring = async (): Promise<KmsKeyringNode> => {
+  const { GENERATOR_KEY_ARN, WRAPPING_KEY_ARN } = process.env;
+  if (!kmsKeyRingConfig || Object.keys(kmsKeyRingConfig).length === 0) {
+    kmsKeyRingConfig = {
+      keyIds: formWrappingKeysArray(WRAPPING_KEY_ARN),
+    };
+  }
+  if (GENERATOR_KEY_ARN) {
+    if (!RegexpKMSKeyArn.test(GENERATOR_KEY_ARN)) {
+      throw new TypeError(
+        "Invalid configuration - ARN for envelope encryption Generator key is invalid."
+      );
+    }
+    kmsKeyRingConfig.generatorKeyId = GENERATOR_KEY_ARN;
+    return new KmsKeyringNode(kmsKeyRingConfig);
+  }
+  throw new TypeError(
+    "Invalid configuration - ARN for envelope encryption Generator key is undefined"
+  );
+};
+
+export default buildKmsKeyring;

--- a/lambda/query-activity-log/models.ts
+++ b/lambda/query-activity-log/models.ts
@@ -29,6 +29,15 @@ export interface ActivityLogEntry {
   truncated: boolean;
 }
 
+export interface EncryptedActivityLogEntry {
+  event_type: string;
+  session_id: string;
+  user_id: string;
+  timestamp: number;
+  activities: string;
+  truncated: boolean;
+}
+
 export interface UserActivityLog {
   txmaEvent: TxmaEvent;
   activityLogEntry: ActivityLogEntry | undefined;

--- a/lambda/query-activity-log/package-lock.json
+++ b/lambda/query-activity-log/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "OGL",
       "dependencies": {
+        "@aws-crypto/client-node": "^4.0.0",
         "@aws-sdk/client-dynamodb": "^3.382.0",
         "@aws-sdk/client-sqs": "^3.382.0",
         "@aws-sdk/lib-dynamodb": "^3.382.0",
@@ -18,6 +19,7 @@
       "devDependencies": {
         "@types/aws-lambda": "^8.10.119",
         "@types/jest": "^29.5.0",
+        "@types/jest-when": "^3.5.2",
         "@types/mocha": "^10.0.1",
         "@typescript-eslint/eslint-plugin": "^5.40.0",
         "aws-sdk-client-mock": "^2.0.0",
@@ -30,6 +32,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.5.0",
+        "jest-when": "^3.6.0",
         "prettier": "^2.7.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
@@ -49,6 +52,59 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-crypto/cache-material": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-4.0.0.tgz",
+      "integrity": "sha512-14m9QPzgMJZ2QdbiM7LCMKgqmONx+/9+Zm5YlXJmhP6Ue+qgniCs5MBOT99WKF50sihcjlA8cVbOUBBJh9t1mg==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/cache-material/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/cache-material/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@aws-crypto/caching-materials-manager-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-4.0.0.tgz",
+      "integrity": "sha512-uPhbFMyiHImEsYIZRuzwMO/VS/tzdUMKCN+p9/Hg5I2r97riqPU5ukfjA8whAsVygGNWRuhlnrwBdjwRE+MZuw==",
+      "dependencies": {
+        "@aws-crypto/cache-material": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/client-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-4.0.0.tgz",
+      "integrity": "sha512-hsYDRSY2MSaAS5AcToR4oSS3sZINVXlOIutJzNkLSLEJuiYwiycJJrILRDCQJk+G6XhT7oJeqbmxFjRA7X83KA==",
+      "dependencies": {
+        "@aws-crypto/caching-materials-manager-node": "^4.0.0",
+        "@aws-crypto/decrypt-node": "^4.0.0",
+        "@aws-crypto/encrypt-node": "^4.0.0",
+        "@aws-crypto/kms-keyring-node": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-aes-keyring-node": "^4.0.0",
+        "@aws-crypto/raw-rsa-keyring-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
@@ -64,6 +120,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-crypto/decrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-4.0.0.tgz",
+      "integrity": "sha512-8xJ0Bjr0l4sBKpNM+zxAqfgUlcZxb/Jqj8IOTzL5IXEO301KH/qNJ1saI37Epmb0v9iKfmCou1D8pu9Y9GnuMw==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/encrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-4.0.0.tgz",
+      "integrity": "sha512-p/iSjYh3u4KFet9vmlnGn2YYf+j3aTQxh5SoxpkxnzSVvH3Sc/Ul5mPu13hIatIjrpnJGH5JNdT98igtsatWxA==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/hkdf-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-4.0.0.tgz",
+      "integrity": "sha512-FytH3TF9c0OP+vnicc4YJoxoFoLajdRzzuRchDHmh4yXk32lj/HzgXGPfj+kSyy0chkh4XVONh2/zMRmqsA/hQ==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -76,6 +166,89 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/kms-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-4.0.0.tgz",
+      "integrity": "sha512-05jqVPbgzZA3R5ZBZznUtc3T9SNAdaLptRU4bnwHeB5kxrhTU8vT+Mabp9vvqhdRauPkZMZvWpvTSWIyDXiYdA==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/kms-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-O3zjC4njVEUrgRUOpFlr4vkbGX1D2XBS9tBMJeBh5VR2Rr/j0ogiEMed6iG1VaFx3ulZ/9Ozq7VxlZxyNCx0fg==",
+      "dependencies": {
+        "@aws-crypto/kms-keyring": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-sdk/client-kms": "^3.362.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/material-management": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-4.0.0.tgz",
+      "integrity": "sha512-1hVZVxIZBc47h599h6jiBkNJnPvckvk1CSDZ9Bi/aCsqVYDFza9frki7+dOsMJu5zYB0cL/H3u1MtuUZEDlsXw==",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/material-management-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-4.0.0.tgz",
+      "integrity": "sha512-urGhjEibLj3atMeUl8RjqmADN8cvTFFhQixvjvoQItU90t4LTPCaHBm+f52QHNhAmGEzBcKFcNBeItNTsed/Cg==",
+      "dependencies": {
+        "@aws-crypto/hkdf-node": "^4.0.0",
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-aes-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-ioXTDkEkVldm8Hmq8o1oWWdAlNz9OHiz7lMaWcAtDBJ+FDuf4pwmgX4sZyYyfs2JHhNDy9gq+L4xPp/oVIoNBw==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-4.0.0.tgz",
+      "integrity": "sha512-Iw+WxKWM4YWAfL5xAB8wNXoCIRJr3ohH1OaGUNP5bKTR2IxDB9ALsRxdI9f61DIwWFsHAgsjIH2qecbW4RDC3Q==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-rsa-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-o1wCF8gRStr3tIMYeu46u+gYPexvNQ+JDaLzGqe9nH0dRXADDG9w5NSdx0kVmFAMvLUgJJyULcwKU2e7o4Ucpg==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/serialize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-4.0.0.tgz",
+      "integrity": "sha512-bi3h2KA+vktnWDG2q/J7Pjgg0MsSgsytH4ZfDztj9KgKRIp9Jq0z8KcIpNK47osNG4MxOjjgqXCZsxp1bnIwjQ==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      }
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
@@ -184,6 +357,444 @@
         "@smithy/util-waiter": "^2.0.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.410.0.tgz",
+      "integrity": "sha512-HiNJStZd9EFXPt70Z/3011RmLlE+FRvRVNDCoBRuLSgvxt51fLcUY0iDpteg46mvKZT+ABj09Cxxxf9Zk3gJrA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.410.0",
+        "@aws-sdk/credential-provider-node": "3.410.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/client-sso": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.410.0.tgz",
+      "integrity": "sha512-MC9GrgwtlOuSL2WS3DRM3dQ/5y+49KSMMJRH6JiEcU5vE0dX/OtEcX+VfEwpi73x5pSfIjm7xnzjzOFx+sQBIg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/client-sts": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.410.0.tgz",
+      "integrity": "sha512-e6VMrBJtnTxxUXwDmkADGIvyppmDMFf4+cGGA68tVCUm1cFNlCI6M/67bVSIPN/WVKAAfhEL5O2vVXCM7aatYg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.410.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-sdk-sts": "3.410.0",
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.410.0.tgz",
+      "integrity": "sha512-c7TB9LbN0PkFOsXI0lcRJnqPNOmc4VBvrHf8jP/BkTDg4YUoKQKOFd4d0SqzODmlZiAyoMQVZTR4ISZo95Zj4Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.410.0.tgz",
+      "integrity": "sha512-D8rcr5bRCFD0f42MPQ7K6TWZq5d3pfqrKINL1/bpfkK5BJbvq1BGYmR88UC6CLpTRtZ1LHY2HgYG0fp/2zjjww==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.410.0",
+        "@aws-sdk/credential-provider-process": "3.410.0",
+        "@aws-sdk/credential-provider-sso": "3.410.0",
+        "@aws-sdk/credential-provider-web-identity": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.410.0.tgz",
+      "integrity": "sha512-0wmVm33T/j1FS7MZ/j+WsPlgSc0YnCXnpbWSov1Mn6R86SHI2b2JhdIPRRE4XbGfyW2QGNUl2CwoZVaqhXeF5g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.410.0",
+        "@aws-sdk/credential-provider-ini": "3.410.0",
+        "@aws-sdk/credential-provider-process": "3.410.0",
+        "@aws-sdk/credential-provider-sso": "3.410.0",
+        "@aws-sdk/credential-provider-web-identity": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.410.0.tgz",
+      "integrity": "sha512-BMju1hlDCDNkkSZpKF5SQ8G0WCLRj6/Jvw9QmudLHJuVwYJXEW1r2AsVMg98OZ3hB9G+MAvHruHZIbMiNmUMXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.410.0.tgz",
+      "integrity": "sha512-zEaoY/sY+KYTlQUkp9dvveAHf175b8RIt0DsQkDrRPtrg/RBHR00r5rFvz9+nrwsR8546RaBU7h/zzTaQGhmcA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.410.0",
+        "@aws-sdk/token-providers": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.410.0.tgz",
+      "integrity": "sha512-cE0l8LmEHdWbDkdPNgrfdYSgp4/cIVXrjUKI1QCATA729CrHZ/OQjB/maOBOrMHO9YTiggko887NkslVvwVB7w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.410.0.tgz",
+      "integrity": "sha512-ED/OVcyITln5rrxnajZP+V0PN1nug+gSDHJDqdDo/oLy7eiDr/ZWn3nlWW7WcMplQ1/Jnb+hK0UetBp/25XooA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.410.0.tgz",
+      "integrity": "sha512-YtmKYCVtBfScq3/UFJk+aSZOktKJBNZL9DaSc2aPcy/goCVsYDOkGwtHk0jIkC1JRSNCkVTqL7ya60sSr8zaQQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.410.0.tgz",
+      "integrity": "sha512-KWaes5FLzRqj28vaIEE4Bimpga2E596WdPF2HaH6zsVMJddoRDsc3ZX9ZhLOGrXzIO1RqBd0QxbLrM0S/B2aOQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.410.0.tgz",
+      "integrity": "sha512-YfBpctDocRR4CcROoDueJA7D+aMLBV8nTFfmVNdLLLgyuLZ/AUR11VQSu1lf9gQZKl8IpKE/BLf2fRE/qV1ZuA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.410.0.tgz",
+      "integrity": "sha512-KBAZ/eoAJUSJv5us2HsKwK2OszG2s9FEyKpEhgnHLcbbKzW873zHBH5GcOGEQu4AWArTy2ndzJu3FF+9/J9hJQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.410.0.tgz",
+      "integrity": "sha512-ZayDtLfvCZUohSxQc/49BfoU/y6bDHLfLdyyUJbJ54Sv8zQcrmdyKvCBFUZwE6tHQgAmv9/ZT18xECMl+xiONA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/token-providers": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.410.0.tgz",
+      "integrity": "sha512-d5Nc0xydkH/X0LA1HDyhGY5sEv4LuADFk+QpDtT8ogLilcre+b1jpdY8Sih/gd1KoGS1H+d1tz2hSGwUHAbUbw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/types": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.410.0.tgz",
+      "integrity": "sha512-D7iaUCszv/v04NDaZUmCmekamy6VD/lKozm/3gS9+dkfU6cC2CsNoUfPV8BlV6dPdw0oWgF91am3I1stdvfVrQ==",
+      "dependencies": {
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.410.0.tgz",
+      "integrity": "sha512-iNiqJyC7N3+8zFwnXUqcWSxrZecVZLToo1iTQQdeYL2af1IcOtRgb7n8jpAI/hmXhBSx2+3RI+Y7pxyFo1vu+w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.410.0.tgz",
+      "integrity": "sha512-i1G/XGpXGMRT2zEiAhi1xucJsfCWk8nNYjk/LbC0sA+7B9Huri96YAzVib12wkHPsJQvZxZC6CpQDIHWm4lXMA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/types": "^2.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.410.0.tgz",
+      "integrity": "sha512-bK70t1jHRl8HrJXd4hEIwc5PBZ7U0w+81AKFnanIVKZwZedd6nLibUXDTK14z/Jp2GFcBqd4zkt2YLGkRt/U4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.410.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/types": "^2.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@smithy/protocol-http": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+      "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1972,11 +2583,11 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-      "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.7.tgz",
+      "integrity": "sha512-rITz65zk8QA3GQ1OeoJ3/Q4+8j/HqubWU8TBqk57BMYTOX+P+LNMoVHPqzLHhE6qKot5muhThNCYvOKNt7ojJA==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1984,11 +2595,12 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-      "integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.8.tgz",
+      "integrity": "sha512-e7mwQteHjo9S1GK+TfzP3o7ujE2ZK30d6wkv5brKtabrZF7MBflj9CwUP2XYuOYebdWirHOtv8ZfkMrpcbJfYw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1998,14 +2610,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-      "integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.10.tgz",
+      "integrity": "sha512-may2/gYlDip2rjlU1Z5fcCEWY0Fu3tSu/HykgZrLfb2/171P6OYuz7dGNKBOCS1W57vP4W5wmUhm0WGehrixig==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2024,23 +2636,35 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-      "integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.3.tgz",
+      "integrity": "sha512-kUg+Ey4mJeR/3+Ponuhb1rsmsfZRwjCLvC+WcPgeI+ittretEzuWAPN+9anD0HJEoApVjHpndzxPtlncbCUJDQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/querystring-builder": "^2.0.7",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
-    "node_modules/@smithy/hash-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-      "integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+      "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.7.tgz",
+      "integrity": "sha512-aB5lvIDP1v+ZUUS8ek3XW5xnZ6jUQ86JXqG7a5jMP6AbjAc3439mIbs6+f1EQ5MtYmrQCEtRRyvv5QofvotH0w==",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2050,11 +2674,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-      "integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.7.tgz",
+      "integrity": "sha512-qVOZnHFPzQo4BS47/PANHX32Y69c0tJxKBkqTL795D/DKInqBwmBO/m1gS7v0ZQqmtCuoy2l87RflQfRY2xEIw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -2080,12 +2704,24 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-      "integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.9.tgz",
+      "integrity": "sha512-2XVFsGqswxrIBi0w4Njwzb1zsbte26U513K+WPFm9z6SB/3WR5/VBVjTaTcamrXznTAqBjTwTL0Ysisv1dW0Rw==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+      "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2093,13 +2729,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-      "integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.7.tgz",
+      "integrity": "sha512-4/L0wV7PzHEprJB0gazSTIwlW/2cCfwC9EHavUMhoCyl1tLer6CJwDbAMit1IMvwbHkwuKopueb8dFPHfpS2Pw==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2108,13 +2744,14 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-      "integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.10.tgz",
+      "integrity": "sha512-VwAQOR5Rh/y9BzUgb5DzUk7qYBiMZu3pEQa5EwwAf/F7lpMuNildGrAxtDmsXk90490FJwa6LyFknXP3kO5BnA==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/protocol-http": "^3.0.3",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
@@ -2124,12 +2761,24 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-      "integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+      "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.7.tgz",
+      "integrity": "sha512-tOldis4PUNafdGErLZ+33p9Pf3MmTlLa176X321Z6ZaCf1XNEow9m3T5vXrcHErVAvjPG0mp3l54J94HnPc+rQ==",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2148,13 +2797,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-      "integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.10.tgz",
+      "integrity": "sha512-e5MiLH5Eu+BbYsmhZIkvUKCzite6JCBPL75PNjlRK2TWvSpfp19hNf2SiJIQbPalcFj5zlyBvtcEkF1sfYIdhg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/shared-ini-file-loader": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/shared-ini-file-loader": "^2.0.9",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2162,14 +2811,26 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-      "integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.3.tgz",
+      "integrity": "sha512-TGkgpx68SqvbspVHaG3iwqP2mKYOT4whiq7Kv2X9v+InngL4MkpH3LQ0Dk7kbloahZr+hAOyb6s8D7T8TXRrzA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.7",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/querystring-builder": "^2.0.7",
+        "@smithy/types": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+      "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+      "dependencies": {
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2177,11 +2838,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-      "integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.8.tgz",
+      "integrity": "sha512-oaaP/i7bGG8XbxG9Kx4PZh83iJ2jo/vt8RmJdi9hmc8APBaW1HGDperVXDCyPQdVYXmiqrtxc/rPImyBma1G3A==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2201,11 +2862,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-      "integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.7.tgz",
+      "integrity": "sha512-RPHnqt4iH1Kwp1Zbf4gJI88hZiynEZjE5hEWJNBmKqCe1Q6v7HBLtaovTaiuYaMEmPyb2KxOi3lISAdT6uuPqw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2214,11 +2875,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-      "integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.7.tgz",
+      "integrity": "sha512-Cwi/Hgs73nbLKfgH7dXAxzvDxyTrK+BLrlAd0KXU7xcBR94V132nvxoq39BMWckYAPmnMwxCwq8uusNH4Dnagw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2234,11 +2895,11 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-      "integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.9.tgz",
+      "integrity": "sha512-vBLgJI+Qpz1TZ0W2kUBOmG2Q+geVEhiXE99UX02+UFag2WzOQ6frvV6rpadwJu0uwF02GG620NbiKGboqZ19YA==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2264,13 +2925,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-      "integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.4.tgz",
+      "integrity": "sha512-KRQvYYjEGqvmwnKSAZ8EL0hZvPxGQMYbAKS/AMGq2fuRmwAlinSVJ/fkIs65bZp2oYjcskd1ZgKcP+2UDjNPTQ==",
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.0.2",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-stream": "^2.0.10",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2278,9 +2939,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-cS48e4Yawb6pGakj7DBJUIPFIkqnUWyXTe2ndPRNagD73b6kEJqTc8bhTyfUve0A+sijK256UKE0J1juAfCeDA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2289,12 +2950,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-      "integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.7.tgz",
+      "integrity": "sha512-SwMl1Lq3yFR2hzhwWYKg04uJHpfcXWMBPycm4Z8GkLI6Dw7rJNDApEbMtujlYw6pVP2WKbrpaGHjQ9MdP92kMQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/querystring-parser": "^2.0.7",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -2319,9 +2980,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
-      "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2353,12 +3014,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-      "integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.8.tgz",
+      "integrity": "sha512-8znx01mkmfKxhiSB2bOF5eMutuCLMd8m2Kh0ulRp8vgzhwRLDJoU6aHSEUoNptbuTAtiFf4u0gpkYC2XfbWwuA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2367,15 +3028,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-      "integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.10.tgz",
+      "integrity": "sha512-QUcUckL4ZqDFVwLnh7zStRUnXtTC6hcJZ4FmMqnxlPcL33Rko0sMQwrMDnMdzF3rS3wvqugAaq3zzop1HCluvw==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/credential-provider-imds": "^2.0.1",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/credential-provider-imds": "^2.0.10",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2417,13 +3078,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-      "integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.10.tgz",
+      "integrity": "sha512-2EgK5cBiv9OaDmhSXmsZY8ZByBl1dg/Tbc51iBJ5GkLGVYhaA6/1l6vHHV41m4Im3D0XfZV1tmeLlQgmRnYsTQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -2541,6 +3202,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -2584,6 +3253,15 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2596,6 +3274,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -2605,8 +3288,7 @@
     "node_modules/@types/node": {
       "version": "18.15.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
-      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
-      "dev": true
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -3065,6 +3747,22 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -3406,6 +4104,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -3816,6 +4519,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.335.tgz",
@@ -3839,6 +4553,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.12.0",
@@ -5216,8 +5938,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -6203,6 +6924,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-when": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.6.0.tgz",
+      "integrity": "sha512-+cZWTy0ekAJo7M9Om0Scdor1jm3wDiYJWmXE8U22UVnkH54YCXAuaqz3P+up/FdtOg8g4wHOxV7Thd7nKhT6Dg==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
@@ -6504,6 +7234,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6728,7 +7463,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7142,6 +7876,19 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -7278,6 +8025,25 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -7291,6 +8057,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -7482,6 +8253,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7989,6 +8773,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8127,8 +8916,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -8218,6 +9006,58 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@aws-crypto/cache-material": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-4.0.0.tgz",
+      "integrity": "sha512-14m9QPzgMJZ2QdbiM7LCMKgqmONx+/9+Zm5YlXJmhP6Ue+qgniCs5MBOT99WKF50sihcjlA8cVbOUBBJh9t1mg==",
+      "requires": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@aws-crypto/caching-materials-manager-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-4.0.0.tgz",
+      "integrity": "sha512-uPhbFMyiHImEsYIZRuzwMO/VS/tzdUMKCN+p9/Hg5I2r97riqPU5ukfjA8whAsVygGNWRuhlnrwBdjwRE+MZuw==",
+      "requires": {
+        "@aws-crypto/cache-material": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/client-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-4.0.0.tgz",
+      "integrity": "sha512-hsYDRSY2MSaAS5AcToR4oSS3sZINVXlOIutJzNkLSLEJuiYwiycJJrILRDCQJk+G6XhT7oJeqbmxFjRA7X83KA==",
+      "requires": {
+        "@aws-crypto/caching-materials-manager-node": "^4.0.0",
+        "@aws-crypto/decrypt-node": "^4.0.0",
+        "@aws-crypto/encrypt-node": "^4.0.0",
+        "@aws-crypto/kms-keyring-node": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-aes-keyring-node": "^4.0.0",
+        "@aws-crypto/raw-rsa-keyring-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
     "@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
@@ -8235,6 +9075,40 @@
         }
       }
     },
+    "@aws-crypto/decrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-4.0.0.tgz",
+      "integrity": "sha512-8xJ0Bjr0l4sBKpNM+zxAqfgUlcZxb/Jqj8IOTzL5IXEO301KH/qNJ1saI37Epmb0v9iKfmCou1D8pu9Y9GnuMw==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/encrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-4.0.0.tgz",
+      "integrity": "sha512-p/iSjYh3u4KFet9vmlnGn2YYf+j3aTQxh5SoxpkxnzSVvH3Sc/Ul5mPu13hIatIjrpnJGH5JNdT98igtsatWxA==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/hkdf-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-4.0.0.tgz",
+      "integrity": "sha512-FytH3TF9c0OP+vnicc4YJoxoFoLajdRzzuRchDHmh4yXk32lj/HzgXGPfj+kSyy0chkh4XVONh2/zMRmqsA/hQ==",
+      "requires": {
+        "tslib": "^2.2.0"
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -8248,6 +9122,89 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
+      }
+    },
+    "@aws-crypto/kms-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-4.0.0.tgz",
+      "integrity": "sha512-05jqVPbgzZA3R5ZBZznUtc3T9SNAdaLptRU4bnwHeB5kxrhTU8vT+Mabp9vvqhdRauPkZMZvWpvTSWIyDXiYdA==",
+      "requires": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/kms-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-O3zjC4njVEUrgRUOpFlr4vkbGX1D2XBS9tBMJeBh5VR2Rr/j0ogiEMed6iG1VaFx3ulZ/9Ozq7VxlZxyNCx0fg==",
+      "requires": {
+        "@aws-crypto/kms-keyring": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-sdk/client-kms": "^3.362.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/material-management": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-4.0.0.tgz",
+      "integrity": "sha512-1hVZVxIZBc47h599h6jiBkNJnPvckvk1CSDZ9Bi/aCsqVYDFza9frki7+dOsMJu5zYB0cL/H3u1MtuUZEDlsXw==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/material-management-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-4.0.0.tgz",
+      "integrity": "sha512-urGhjEibLj3atMeUl8RjqmADN8cvTFFhQixvjvoQItU90t4LTPCaHBm+f52QHNhAmGEzBcKFcNBeItNTsed/Cg==",
+      "requires": {
+        "@aws-crypto/hkdf-node": "^4.0.0",
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/raw-aes-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-ioXTDkEkVldm8Hmq8o1oWWdAlNz9OHiz7lMaWcAtDBJ+FDuf4pwmgX4sZyYyfs2JHhNDy9gq+L4xPp/oVIoNBw==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/raw-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-4.0.0.tgz",
+      "integrity": "sha512-Iw+WxKWM4YWAfL5xAB8wNXoCIRJr3ohH1OaGUNP5bKTR2IxDB9ALsRxdI9f61DIwWFsHAgsjIH2qecbW4RDC3Q==",
+      "requires": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/raw-rsa-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-o1wCF8gRStr3tIMYeu46u+gYPexvNQ+JDaLzGqe9nH0dRXADDG9w5NSdx0kVmFAMvLUgJJyULcwKU2e7o4Ucpg==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@aws-crypto/serialize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-4.0.0.tgz",
+      "integrity": "sha512-bi3h2KA+vktnWDG2q/J7Pjgg0MsSgsytH4ZfDztj9KgKRIp9Jq0z8KcIpNK47osNG4MxOjjgqXCZsxp1bnIwjQ==",
+      "requires": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
       }
     },
     "@aws-crypto/sha256-browser": {
@@ -8365,6 +9322,378 @@
         "@smithy/util-waiter": "^2.0.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-kms": {
+      "version": "3.410.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.410.0.tgz",
+      "integrity": "sha512-HiNJStZd9EFXPt70Z/3011RmLlE+FRvRVNDCoBRuLSgvxt51fLcUY0iDpteg46mvKZT+ABj09Cxxxf9Zk3gJrA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.410.0",
+        "@aws-sdk/credential-provider-node": "3.410.0",
+        "@aws-sdk/middleware-host-header": "3.410.0",
+        "@aws-sdk/middleware-logger": "3.410.0",
+        "@aws-sdk/middleware-recursion-detection": "3.410.0",
+        "@aws-sdk/middleware-signing": "3.410.0",
+        "@aws-sdk/middleware-user-agent": "3.410.0",
+        "@aws-sdk/types": "3.410.0",
+        "@aws-sdk/util-endpoints": "3.410.0",
+        "@aws-sdk/util-user-agent-browser": "3.410.0",
+        "@aws-sdk/util-user-agent-node": "3.410.0",
+        "@smithy/config-resolver": "^2.0.7",
+        "@smithy/fetch-http-handler": "^2.1.2",
+        "@smithy/hash-node": "^2.0.6",
+        "@smithy/invalid-dependency": "^2.0.6",
+        "@smithy/middleware-content-length": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.0.6",
+        "@smithy/middleware-retry": "^2.0.9",
+        "@smithy/middleware-serde": "^2.0.6",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.9",
+        "@smithy/node-http-handler": "^2.1.2",
+        "@smithy/protocol-http": "^3.0.2",
+        "@smithy/smithy-client": "^2.1.3",
+        "@smithy/types": "^2.3.0",
+        "@smithy/url-parser": "^2.0.6",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.7",
+        "@smithy/util-defaults-mode-node": "^2.0.9",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.410.0.tgz",
+          "integrity": "sha512-MC9GrgwtlOuSL2WS3DRM3dQ/5y+49KSMMJRH6JiEcU5vE0dX/OtEcX+VfEwpi73x5pSfIjm7xnzjzOFx+sQBIg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.410.0",
+            "@aws-sdk/middleware-logger": "3.410.0",
+            "@aws-sdk/middleware-recursion-detection": "3.410.0",
+            "@aws-sdk/middleware-user-agent": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@aws-sdk/util-endpoints": "3.410.0",
+            "@aws-sdk/util-user-agent-browser": "3.410.0",
+            "@aws-sdk/util-user-agent-node": "3.410.0",
+            "@smithy/config-resolver": "^2.0.7",
+            "@smithy/fetch-http-handler": "^2.1.2",
+            "@smithy/hash-node": "^2.0.6",
+            "@smithy/invalid-dependency": "^2.0.6",
+            "@smithy/middleware-content-length": "^2.0.8",
+            "@smithy/middleware-endpoint": "^2.0.6",
+            "@smithy/middleware-retry": "^2.0.9",
+            "@smithy/middleware-serde": "^2.0.6",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.9",
+            "@smithy/node-http-handler": "^2.1.2",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/smithy-client": "^2.1.3",
+            "@smithy/types": "^2.3.0",
+            "@smithy/url-parser": "^2.0.6",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.7",
+            "@smithy/util-defaults-mode-node": "^2.0.9",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.410.0.tgz",
+          "integrity": "sha512-e6VMrBJtnTxxUXwDmkADGIvyppmDMFf4+cGGA68tVCUm1cFNlCI6M/67bVSIPN/WVKAAfhEL5O2vVXCM7aatYg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/credential-provider-node": "3.410.0",
+            "@aws-sdk/middleware-host-header": "3.410.0",
+            "@aws-sdk/middleware-logger": "3.410.0",
+            "@aws-sdk/middleware-recursion-detection": "3.410.0",
+            "@aws-sdk/middleware-sdk-sts": "3.410.0",
+            "@aws-sdk/middleware-signing": "3.410.0",
+            "@aws-sdk/middleware-user-agent": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@aws-sdk/util-endpoints": "3.410.0",
+            "@aws-sdk/util-user-agent-browser": "3.410.0",
+            "@aws-sdk/util-user-agent-node": "3.410.0",
+            "@smithy/config-resolver": "^2.0.7",
+            "@smithy/fetch-http-handler": "^2.1.2",
+            "@smithy/hash-node": "^2.0.6",
+            "@smithy/invalid-dependency": "^2.0.6",
+            "@smithy/middleware-content-length": "^2.0.8",
+            "@smithy/middleware-endpoint": "^2.0.6",
+            "@smithy/middleware-retry": "^2.0.9",
+            "@smithy/middleware-serde": "^2.0.6",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.9",
+            "@smithy/node-http-handler": "^2.1.2",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/smithy-client": "^2.1.3",
+            "@smithy/types": "^2.3.0",
+            "@smithy/url-parser": "^2.0.6",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.7",
+            "@smithy/util-defaults-mode-node": "^2.0.9",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.410.0.tgz",
+          "integrity": "sha512-c7TB9LbN0PkFOsXI0lcRJnqPNOmc4VBvrHf8jP/BkTDg4YUoKQKOFd4d0SqzODmlZiAyoMQVZTR4ISZo95Zj4Q==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.410.0.tgz",
+          "integrity": "sha512-D8rcr5bRCFD0f42MPQ7K6TWZq5d3pfqrKINL1/bpfkK5BJbvq1BGYmR88UC6CLpTRtZ1LHY2HgYG0fp/2zjjww==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.410.0",
+            "@aws-sdk/credential-provider-process": "3.410.0",
+            "@aws-sdk/credential-provider-sso": "3.410.0",
+            "@aws-sdk/credential-provider-web-identity": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.410.0.tgz",
+          "integrity": "sha512-0wmVm33T/j1FS7MZ/j+WsPlgSc0YnCXnpbWSov1Mn6R86SHI2b2JhdIPRRE4XbGfyW2QGNUl2CwoZVaqhXeF5g==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.410.0",
+            "@aws-sdk/credential-provider-ini": "3.410.0",
+            "@aws-sdk/credential-provider-process": "3.410.0",
+            "@aws-sdk/credential-provider-sso": "3.410.0",
+            "@aws-sdk/credential-provider-web-identity": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/credential-provider-imds": "^2.0.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.410.0.tgz",
+          "integrity": "sha512-BMju1hlDCDNkkSZpKF5SQ8G0WCLRj6/Jvw9QmudLHJuVwYJXEW1r2AsVMg98OZ3hB9G+MAvHruHZIbMiNmUMXQ==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.410.0.tgz",
+          "integrity": "sha512-zEaoY/sY+KYTlQUkp9dvveAHf175b8RIt0DsQkDrRPtrg/RBHR00r5rFvz9+nrwsR8546RaBU7h/zzTaQGhmcA==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.410.0",
+            "@aws-sdk/token-providers": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.410.0.tgz",
+          "integrity": "sha512-cE0l8LmEHdWbDkdPNgrfdYSgp4/cIVXrjUKI1QCATA729CrHZ/OQjB/maOBOrMHO9YTiggko887NkslVvwVB7w==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.410.0.tgz",
+          "integrity": "sha512-ED/OVcyITln5rrxnajZP+V0PN1nug+gSDHJDqdDo/oLy7eiDr/ZWn3nlWW7WcMplQ1/Jnb+hK0UetBp/25XooA==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.410.0.tgz",
+          "integrity": "sha512-YtmKYCVtBfScq3/UFJk+aSZOktKJBNZL9DaSc2aPcy/goCVsYDOkGwtHk0jIkC1JRSNCkVTqL7ya60sSr8zaQQ==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.410.0.tgz",
+          "integrity": "sha512-KWaes5FLzRqj28vaIEE4Bimpga2E596WdPF2HaH6zsVMJddoRDsc3ZX9ZhLOGrXzIO1RqBd0QxbLrM0S/B2aOQ==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.410.0.tgz",
+          "integrity": "sha512-YfBpctDocRR4CcROoDueJA7D+aMLBV8nTFfmVNdLLLgyuLZ/AUR11VQSu1lf9gQZKl8IpKE/BLf2fRE/qV1ZuA==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.410.0.tgz",
+          "integrity": "sha512-KBAZ/eoAJUSJv5us2HsKwK2OszG2s9FEyKpEhgnHLcbbKzW873zHBH5GcOGEQu4AWArTy2ndzJu3FF+9/J9hJQ==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/signature-v4": "^2.0.0",
+            "@smithy/types": "^2.3.0",
+            "@smithy/util-middleware": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.410.0.tgz",
+          "integrity": "sha512-ZayDtLfvCZUohSxQc/49BfoU/y6bDHLfLdyyUJbJ54Sv8zQcrmdyKvCBFUZwE6tHQgAmv9/ZT18xECMl+xiONA==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@aws-sdk/util-endpoints": "3.410.0",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.410.0.tgz",
+          "integrity": "sha512-d5Nc0xydkH/X0LA1HDyhGY5sEv4LuADFk+QpDtT8ogLilcre+b1jpdY8Sih/gd1KoGS1H+d1tz2hSGwUHAbUbw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.410.0",
+            "@aws-sdk/middleware-logger": "3.410.0",
+            "@aws-sdk/middleware-recursion-detection": "3.410.0",
+            "@aws-sdk/middleware-user-agent": "3.410.0",
+            "@aws-sdk/types": "3.410.0",
+            "@aws-sdk/util-endpoints": "3.410.0",
+            "@aws-sdk/util-user-agent-browser": "3.410.0",
+            "@aws-sdk/util-user-agent-node": "3.410.0",
+            "@smithy/config-resolver": "^2.0.7",
+            "@smithy/fetch-http-handler": "^2.1.2",
+            "@smithy/hash-node": "^2.0.6",
+            "@smithy/invalid-dependency": "^2.0.6",
+            "@smithy/middleware-content-length": "^2.0.8",
+            "@smithy/middleware-endpoint": "^2.0.6",
+            "@smithy/middleware-retry": "^2.0.9",
+            "@smithy/middleware-serde": "^2.0.6",
+            "@smithy/middleware-stack": "^2.0.0",
+            "@smithy/node-config-provider": "^2.0.9",
+            "@smithy/node-http-handler": "^2.1.2",
+            "@smithy/property-provider": "^2.0.0",
+            "@smithy/protocol-http": "^3.0.2",
+            "@smithy/shared-ini-file-loader": "^2.0.6",
+            "@smithy/smithy-client": "^2.1.3",
+            "@smithy/types": "^2.3.0",
+            "@smithy/url-parser": "^2.0.6",
+            "@smithy/util-base64": "^2.0.0",
+            "@smithy/util-body-length-browser": "^2.0.0",
+            "@smithy/util-body-length-node": "^2.1.0",
+            "@smithy/util-defaults-mode-browser": "^2.0.7",
+            "@smithy/util-defaults-mode-node": "^2.0.9",
+            "@smithy/util-retry": "^2.0.0",
+            "@smithy/util-utf8": "^2.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.410.0.tgz",
+          "integrity": "sha512-D7iaUCszv/v04NDaZUmCmekamy6VD/lKozm/3gS9+dkfU6cC2CsNoUfPV8BlV6dPdw0oWgF91am3I1stdvfVrQ==",
+          "requires": {
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.410.0.tgz",
+          "integrity": "sha512-iNiqJyC7N3+8zFwnXUqcWSxrZecVZLToo1iTQQdeYL2af1IcOtRgb7n8jpAI/hmXhBSx2+3RI+Y7pxyFo1vu+w==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.410.0.tgz",
+          "integrity": "sha512-i1G/XGpXGMRT2zEiAhi1xucJsfCWk8nNYjk/LbC0sA+7B9Huri96YAzVib12wkHPsJQvZxZC6CpQDIHWm4lXMA==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/types": "^2.3.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.410.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.410.0.tgz",
+          "integrity": "sha512-bK70t1jHRl8HrJXd4hEIwc5PBZ7U0w+81AKFnanIVKZwZedd6nLibUXDTK14z/Jp2GFcBqd4zkt2YLGkRt/U4A==",
+          "requires": {
+            "@aws-sdk/types": "3.410.0",
+            "@smithy/node-config-provider": "^2.0.9",
+            "@smithy/types": "^2.3.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+          "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+          "requires": {
+            "@smithy/types": "^2.3.1",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-sqs": {
@@ -9778,34 +11107,35 @@
       "dev": true
     },
     "@smithy/abort-controller": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-      "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.7.tgz",
+      "integrity": "sha512-rITz65zk8QA3GQ1OeoJ3/Q4+8j/HqubWU8TBqk57BMYTOX+P+LNMoVHPqzLHhE6qKot5muhThNCYvOKNt7ojJA==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-      "integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.8.tgz",
+      "integrity": "sha512-e7mwQteHjo9S1GK+TfzP3o7ujE2ZK30d6wkv5brKtabrZF7MBflj9CwUP2XYuOYebdWirHOtv8ZfkMrpcbJfYw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-      "integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.10.tgz",
+      "integrity": "sha512-may2/gYlDip2rjlU1Z5fcCEWY0Fu3tSu/HykgZrLfb2/171P6OYuz7dGNKBOCS1W57vP4W5wmUhm0WGehrixig==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
         "tslib": "^2.5.0"
       }
     },
@@ -9821,34 +11151,45 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-      "integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.1.3.tgz",
+      "integrity": "sha512-kUg+Ey4mJeR/3+Ponuhb1rsmsfZRwjCLvC+WcPgeI+ittretEzuWAPN+9anD0HJEoApVjHpndzxPtlncbCUJDQ==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/querystring-builder": "^2.0.7",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+          "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+          "requires": {
+            "@smithy/types": "^2.3.1",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@smithy/hash-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-      "integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.7.tgz",
+      "integrity": "sha512-aB5lvIDP1v+ZUUS8ek3XW5xnZ6jUQ86JXqG7a5jMP6AbjAc3439mIbs6+f1EQ5MtYmrQCEtRRyvv5QofvotH0w==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-      "integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.7.tgz",
+      "integrity": "sha512-qVOZnHFPzQo4BS47/PANHX32Y69c0tJxKBkqTL795D/DKInqBwmBO/m1gS7v0ZQqmtCuoy2l87RflQfRY2xEIw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -9871,47 +11212,70 @@
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-      "integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.9.tgz",
+      "integrity": "sha512-2XVFsGqswxrIBi0w4Njwzb1zsbte26U513K+WPFm9z6SB/3WR5/VBVjTaTcamrXznTAqBjTwTL0Ysisv1dW0Rw==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+          "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+          "requires": {
+            "@smithy/types": "^2.3.1",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-      "integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.7.tgz",
+      "integrity": "sha512-4/L0wV7PzHEprJB0gazSTIwlW/2cCfwC9EHavUMhoCyl1tLer6CJwDbAMit1IMvwbHkwuKopueb8dFPHfpS2Pw==",
       "requires": {
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.7",
+        "@smithy/types": "^2.3.1",
+        "@smithy/url-parser": "^2.0.7",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-      "integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.10.tgz",
+      "integrity": "sha512-VwAQOR5Rh/y9BzUgb5DzUk7qYBiMZu3pEQa5EwwAf/F7lpMuNildGrAxtDmsXk90490FJwa6LyFknXP3kO5BnA==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/protocol-http": "^3.0.3",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+          "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+          "requires": {
+            "@smithy/types": "^2.3.1",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-      "integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.7.tgz",
+      "integrity": "sha512-tOldis4PUNafdGErLZ+33p9Pf3MmTlLa176X321Z6ZaCf1XNEow9m3T5vXrcHErVAvjPG0mp3l54J94HnPc+rQ==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -9924,34 +11288,45 @@
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-      "integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.10.tgz",
+      "integrity": "sha512-e5MiLH5Eu+BbYsmhZIkvUKCzite6JCBPL75PNjlRK2TWvSpfp19hNf2SiJIQbPalcFj5zlyBvtcEkF1sfYIdhg==",
       "requires": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/shared-ini-file-loader": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/shared-ini-file-loader": "^2.0.9",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-      "integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.3.tgz",
+      "integrity": "sha512-TGkgpx68SqvbspVHaG3iwqP2mKYOT4whiq7Kv2X9v+InngL4MkpH3LQ0Dk7kbloahZr+hAOyb6s8D7T8TXRrzA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.7",
+        "@smithy/protocol-http": "^3.0.3",
+        "@smithy/querystring-builder": "^2.0.7",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.3.tgz",
+          "integrity": "sha512-UGfmQNdijlFV+UzgdRyfe05S5vLDdcdkvNcxhGvQ+Er7TjUkZSxjukQB9VXtT8oTHztgOMX74DDlPBsVzZR5Pg==",
+          "requires": {
+            "@smithy/types": "^2.3.1",
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@smithy/property-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-      "integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.8.tgz",
+      "integrity": "sha512-oaaP/i7bGG8XbxG9Kx4PZh83iJ2jo/vt8RmJdi9hmc8APBaW1HGDperVXDCyPQdVYXmiqrtxc/rPImyBma1G3A==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -9965,21 +11340,21 @@
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-      "integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.7.tgz",
+      "integrity": "sha512-RPHnqt4iH1Kwp1Zbf4gJI88hZiynEZjE5hEWJNBmKqCe1Q6v7HBLtaovTaiuYaMEmPyb2KxOi3lISAdT6uuPqw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-      "integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.7.tgz",
+      "integrity": "sha512-Cwi/Hgs73nbLKfgH7dXAxzvDxyTrK+BLrlAd0KXU7xcBR94V132nvxoq39BMWckYAPmnMwxCwq8uusNH4Dnagw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -9989,11 +11364,11 @@
       "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw=="
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-      "integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.9.tgz",
+      "integrity": "sha512-vBLgJI+Qpz1TZ0W2kUBOmG2Q+geVEhiXE99UX02+UFag2WzOQ6frvV6rpadwJu0uwF02GG620NbiKGboqZ19YA==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -10013,31 +11388,31 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-      "integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.4.tgz",
+      "integrity": "sha512-KRQvYYjEGqvmwnKSAZ8EL0hZvPxGQMYbAKS/AMGq2fuRmwAlinSVJ/fkIs65bZp2oYjcskd1ZgKcP+2UDjNPTQ==",
       "requires": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.0.2",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/types": "^2.3.1",
+        "@smithy/util-stream": "^2.0.10",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-cS48e4Yawb6pGakj7DBJUIPFIkqnUWyXTe2ndPRNagD73b6kEJqTc8bhTyfUve0A+sijK256UKE0J1juAfCeDA==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-      "integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.7.tgz",
+      "integrity": "sha512-SwMl1Lq3yFR2hzhwWYKg04uJHpfcXWMBPycm4Z8GkLI6Dw7rJNDApEbMtujlYw6pVP2WKbrpaGHjQ9MdP92kMQ==",
       "requires": {
-        "@smithy/querystring-parser": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/querystring-parser": "^2.0.7",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -10059,9 +11434,9 @@
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.0.0.tgz",
-      "integrity": "sha512-ZV7Z/WHTMxHJe/xL/56qZwSUcl63/5aaPAGjkfynJm4poILjdD4GmFI+V+YWabh2WJIjwTKZ5PNsuvPQKt93Mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
+      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -10084,26 +11459,26 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-      "integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.8.tgz",
+      "integrity": "sha512-8znx01mkmfKxhiSB2bOF5eMutuCLMd8m2Kh0ulRp8vgzhwRLDJoU6aHSEUoNptbuTAtiFf4u0gpkYC2XfbWwuA==",
       "requires": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-      "integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.10.tgz",
+      "integrity": "sha512-QUcUckL4ZqDFVwLnh7zStRUnXtTC6hcJZ4FmMqnxlPcL33Rko0sMQwrMDnMdzF3rS3wvqugAaq3zzop1HCluvw==",
       "requires": {
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/credential-provider-imds": "^2.0.1",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/config-resolver": "^2.0.8",
+        "@smithy/credential-provider-imds": "^2.0.10",
+        "@smithy/node-config-provider": "^2.0.10",
+        "@smithy/property-provider": "^2.0.8",
+        "@smithy/types": "^2.3.1",
         "tslib": "^2.5.0"
       }
     },
@@ -10133,13 +11508,13 @@
       }
     },
     "@smithy/util-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-      "integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.10.tgz",
+      "integrity": "sha512-2EgK5cBiv9OaDmhSXmsZY8ZByBl1dg/Tbc51iBJ5GkLGVYhaA6/1l6vHHV41m4Im3D0XfZV1tmeLlQgmRnYsTQ==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.3",
+        "@smithy/types": "^2.3.1",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -10245,6 +11620,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -10288,6 +11671,15 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "@types/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-1WP+wJDW7h4TYAVLoIebxRIVv8GPk66Qsq2nU7PkwKZ6usurnDQZgk0DfBNKAJ9gVzapCXSV53Vn/3nBHBNzAw==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -10300,6 +11692,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
     "@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -10309,8 +11706,7 @@
     "@types/node": {
       "version": "18.15.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
-      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
-      "dev": true
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew=="
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -10619,6 +12015,24 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -10890,6 +12304,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "bowser": {
       "version": "2.11.0",
@@ -11190,6 +12609,17 @@
         "esutils": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.335.tgz",
@@ -11207,6 +12637,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enhanced-resolve": {
       "version": "5.12.0",
@@ -12216,8 +13654,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.5",
@@ -12939,6 +14376,13 @@
         "string-length": "^4.0.1"
       }
     },
+    "jest-when": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.6.0.tgz",
+      "integrity": "sha512-+cZWTy0ekAJo7M9Om0Scdor1jm3wDiYJWmXE8U22UVnkH54YCXAuaqz3P+up/FdtOg8g4wHOxV7Thd7nKhT6Dg==",
+      "dev": true,
+      "requires": {}
+    },
     "jest-worker": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
@@ -13177,6 +14621,11 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -13350,7 +14799,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -13640,6 +15088,16 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -13727,6 +15185,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -13737,6 +15200,11 @@
         "get-intrinsic": "^1.1.3",
         "is-regex": "^1.1.4"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "7.5.4",
@@ -13896,6 +15364,19 @@
       "dev": true,
       "requires": {
         "internal-slot": "^1.0.4"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "string-length": {
@@ -14244,6 +15725,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -14351,8 +15837,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "4.0.2",

--- a/lambda/query-activity-log/package.json
+++ b/lambda/query-activity-log/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.119",
     "@types/jest": "^29.5.0",
+    "@types/jest-when": "^3.5.2",
     "@types/mocha": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "aws-sdk-client-mock": "^2.0.0",
@@ -25,12 +26,14 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
+    "jest-when": "^3.6.0",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@aws-crypto/client-node": "^4.0.0",
     "@aws-sdk/client-dynamodb": "^3.382.0",
     "@aws-sdk/client-sqs": "^3.382.0",
     "@aws-sdk/lib-dynamodb": "^3.382.0",

--- a/lambda/query-activity-log/tests/decrypt-data.test.ts
+++ b/lambda/query-activity-log/tests/decrypt-data.test.ts
@@ -1,7 +1,15 @@
-import { MessageHeader, buildDecrypt } from "@aws-crypto/client-node";
+import {
+  EncryptionContext,
+  MessageHeader,
+  buildDecrypt,
+} from "@aws-crypto/client-node";
 import { when } from "jest-when";
 
-import decryptData from "../decrypt-data";
+import {
+  decryptData,
+  generateExpectedContext,
+  validateEncryptionContext,
+} from "../decrypt-data";
 
 jest.mock("@aws-crypto/client-node", () => ({
   buildDecrypt: jest.fn().mockReturnValue({
@@ -11,6 +19,89 @@ jest.mock("@aws-crypto/client-node", () => ({
     generatorKeyId: process.env.GENERATOR_KEY_ARN,
   })),
 }));
+
+const awsRegion = "aws-region";
+const accountId = "account-id";
+const environment = "environment";
+const userId = "user-id";
+
+describe("generateExpectedContext", () => {
+  beforeEach(() => {
+    process.env.AWS_REGION = awsRegion;
+    process.env.ACCOUNT_ID = accountId;
+    process.env.ENVIRONMENT = environment;
+  });
+
+  afterEach(() => {
+    delete process.env.AWS_REGION;
+    delete process.env.ACCOUNT_ID;
+    delete process.env.ENVIRONMENT;
+  });
+
+  test("throws an error when AWS_REGION is not defined", () => {
+    delete process.env.AWS_REGION;
+    expect(() => {
+      generateExpectedContext(userId);
+    }).toThrowError("Missing AWS_REGION environment variable");
+  });
+
+  test("throws an error when ACCOUNT_ID is not defined", () => {
+    delete process.env.ACCOUNT_ID;
+    expect(() => {
+      generateExpectedContext(userId);
+    }).toThrowError("Missing ACCOUNT_ID environment variable");
+  });
+
+  test("throws an error when ENVIRONMENT is not defined", () => {
+    delete process.env.ENVIRONMENT;
+    expect(() => {
+      generateExpectedContext(userId);
+    }).toThrowError("Missing ENVIRONMENT environment variable");
+  });
+
+  test("returns the encryption context", () => {
+    const result = generateExpectedContext(userId);
+    const expected = {
+      origin: awsRegion,
+      accountId,
+      stage: environment,
+      userId,
+    };
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("validateEncryptionContext", () => {
+  let expected: EncryptionContext;
+  beforeEach(() => {
+    process.env.AWS_REGION = awsRegion;
+    process.env.ACCOUNT_ID = accountId;
+    process.env.ENVIRONMENT = environment;
+    expected = generateExpectedContext(userId);
+  });
+
+  test("throws an error when the context is empty", () => {
+    expect(() => {
+      validateEncryptionContext({}, expected);
+    }).toThrowError("Encryption context is empty or undefined");
+  });
+
+  test("throws an error when there is a mismatch", () => {
+    const wrongContext = {
+      origin: awsRegion,
+      accountId,
+      stage: environment,
+      userId: "wrong-user-id",
+    };
+    expect(() => {
+      validateEncryptionContext(wrongContext, expected);
+    }).toThrowError("Encryption context mismatch: userId");
+  });
+
+  test("doesn't throw an error when context matches", () => {
+    validateEncryptionContext(expected, expected);
+  });
+});
 
 describe("decryptActivities", () => {
   let encryptedActivities: string;
@@ -27,10 +118,21 @@ describe("decryptActivities", () => {
   it("should decrypt an encrypted string", async () => {
     when(buildDecrypt().decrypt).mockResolvedValue({
       plaintext: Buffer.from(encryptedActivities),
-      messageHeader: {} as MessageHeader,
+      messageHeader: {
+        encryptionContext: {
+          origin: awsRegion,
+          accountId,
+          stage: environment,
+          userId,
+        } as EncryptionContext,
+      } as MessageHeader,
     });
 
-    await decryptData(encryptedActivities);
+    process.env.AWS_REGION = awsRegion;
+    process.env.ACCOUNT_ID = accountId;
+    process.env.ENVIRONMENT = environment;
+
+    await decryptData(encryptedActivities, userId);
     expect(buildDecrypt).toHaveBeenCalled();
     expect(buildDecrypt().decrypt).toHaveBeenCalledWith(
       {
@@ -44,7 +146,7 @@ describe("decryptActivities", () => {
   it("should throw an error if something goes wrong when decrypting", () => {
     when(buildDecrypt().decrypt).mockRejectedValue(new Error("A KMS error"));
     expect(async () => {
-      await decryptData(encryptedActivities);
+      await decryptData(encryptedActivities, userId);
     }).rejects.toThrowError("A KMS error");
   });
 });

--- a/lambda/query-activity-log/tests/decrypt-data.test.ts
+++ b/lambda/query-activity-log/tests/decrypt-data.test.ts
@@ -1,0 +1,50 @@
+import { MessageHeader, buildDecrypt } from "@aws-crypto/client-node";
+import { when } from "jest-when";
+
+import decryptData from "../decrypt-data";
+
+jest.mock("@aws-crypto/client-node", () => ({
+  buildDecrypt: jest.fn().mockReturnValue({
+    decrypt: jest.fn(),
+  }),
+  KmsKeyringNode: jest.fn().mockImplementation(() => ({
+    generatorKeyId: process.env.GENERATOR_KEY_ARN,
+  })),
+}));
+
+describe("decryptActivities", () => {
+  let encryptedActivities: string;
+
+  beforeEach(() => {
+    encryptedActivities = "an-encrypted-string";
+
+    process.env.GENERATOR_KEY_ARN =
+      "arn:aws:kms:eu-west-2:111122223333:key/bc436485-5092-42b8-92a3-0aa8b93536dc";
+    process.env.WRAPPING_KEY_ARN =
+      "arn:aws:kms:eu-west-2:111122223333:key/49c5492b-b1bc-42a8-9a5c-b2015e810c1c";
+  });
+
+  it("should decrypt an encrypted string", async () => {
+    when(buildDecrypt().decrypt).mockResolvedValue({
+      plaintext: Buffer.from(encryptedActivities),
+      messageHeader: {} as MessageHeader,
+    });
+
+    await decryptData(encryptedActivities);
+    expect(buildDecrypt).toHaveBeenCalled();
+    expect(buildDecrypt().decrypt).toHaveBeenCalledWith(
+      {
+        generatorKeyId:
+          "arn:aws:kms:eu-west-2:111122223333:key/bc436485-5092-42b8-92a3-0aa8b93536dc",
+      },
+      encryptedActivities
+    );
+  });
+
+  it("should throw an error if something goes wrong when decrypting", () => {
+    when(buildDecrypt().decrypt).mockRejectedValue(new Error("A KMS error"));
+    expect(async () => {
+      await decryptData(encryptedActivities);
+    }).rejects.toThrowError("A KMS error");
+  });
+});

--- a/lambda/query-activity-log/tests/kms-keyring-builder.test.ts
+++ b/lambda/query-activity-log/tests/kms-keyring-builder.test.ts
@@ -1,0 +1,66 @@
+import { KmsKeyringNode } from "@aws-crypto/client-node";
+import buildKmsKeyring from "../kms-keyring-builder";
+
+const exampleArn =
+  "arn:aws:kms:eu-west-2:111122223333:key/bc436485-5092-42b8-92a3-0aa8b93536dc";
+
+describe("kmsKeyringBuilder", () => {
+  /* 
+  Test order is important as once the wrapping keys have been validated 
+  buildKmsKeyring will not do so again.
+  */
+
+  test("throws error when wrapper key is not valid ARN", async () => {
+    process.env.GENERATOR_KEY_ARN = exampleArn;
+    process.env.WRAPPING_KEY_ARN = "not-valid-arn";
+
+    await expect(async () => {
+      await buildKmsKeyring();
+    }).rejects.toThrowError(
+      "Invalid configuration - ARN for main envelope encryption wrapping key is invalid."
+    );
+  });
+
+  test("throws error when wrapper key is not defined", async () => {
+    process.env.GENERATOR_KEY_ARN = exampleArn;
+    delete process.env.WRAPPING_KEY_ARN;
+
+    await expect(async () => {
+      await buildKmsKeyring();
+    }).rejects.toThrowError(
+      "Invalid configuration - ARN for main envelope encryption wrapping key is undefined."
+    );
+  });
+
+  test("throws error when generator key is not present", async () => {
+    delete process.env.GENERATOR_KEY_ARN;
+    process.env.WRAPPING_KEY_ARN = exampleArn;
+
+    await expect(async () => {
+      await buildKmsKeyring();
+    }).rejects.toThrowError(
+      "Invalid configuration - ARN for envelope encryption Generator key is undefined"
+    );
+  });
+
+  test("throws error when generator key is not valid ARN", async () => {
+    process.env.GENERATOR_KEY_ARN = "not-valid-arn";
+    process.env.WRAPPING_KEY_ARN = exampleArn;
+
+    await expect(async () => {
+      await buildKmsKeyring();
+    }).rejects.toThrowError(
+      "Invalid configuration - ARN for envelope encryption Generator key is invalid."
+    );
+  });
+
+  test("construct KmsKeyring corretly", async () => {
+    process.env.GENERATOR_KEY_ARN = exampleArn;
+    process.env.WRAPPING_KEY_ARN = exampleArn;
+
+    const kmsKeyring: KmsKeyringNode = await buildKmsKeyring();
+    expect(kmsKeyring.keyIds).toHaveLength(1);
+    expect(kmsKeyring.generatorKeyId).toEqual(exampleArn);
+    expect(kmsKeyring.keyIds[0]).toEqual(exampleArn);
+  });
+});

--- a/lambda/query-activity-log/tests/test-helpers.ts
+++ b/lambda/query-activity-log/tests/test-helpers.ts
@@ -1,5 +1,11 @@
 import { DynamoDBStreamEvent, DynamoDBRecord } from "aws-lambda";
-import { TxmaEvent, UserData } from "../models";
+import {
+  Activity,
+  ActivityLogEntry,
+  EncryptedActivityLogEntry,
+  TxmaEvent,
+  UserData,
+} from "../models";
 
 export const eventType = "AUTH_AUTH_CODE_ISSUED";
 export const randomEventType = "AUTH_OTHER_RANDOM_EVENT";
@@ -12,6 +18,13 @@ export const tableName = "TableName";
 export const messageId = "MyMessageId";
 export const queueUrl = "http://my_queue_url";
 export const timestamp = date.valueOf();
+export const activity: Activity = {
+  type: eventType,
+  client_id: clientId,
+  timestamp,
+  event_id: eventId,
+};
+export const activities = [activity, activity];
 const timestampFormatted = date.toISOString();
 const govukSigninJourneyId = "abc123";
 
@@ -88,4 +101,22 @@ export const TEST_TXMA_EVENT: TxmaEvent = generateTestTxmaEvent();
 
 export const MUCKY_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {
   Records: [generateDynamoSteamRecord(randomEventType)],
+};
+
+export const TEST_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
+  session_id: sessionId,
+  user_id: userId,
+  event_type: eventType,
+  timestamp,
+  activities,
+  truncated: false,
+};
+
+export const TEST_ENCRYPTED_ACTIVITY_LOG_ENTRY: EncryptedActivityLogEntry = {
+  session_id: sessionId,
+  user_id: userId,
+  event_type: eventType,
+  timestamp,
+  activities: JSON.stringify(activities),
+  truncated: false,
 };


### PR DESCRIPTION
## Proposed changes

### What changed

Update the `query-activity-log` lambda to decrypt the user's activity history in the query result from DynamoDB. 

This closely follows the implementation of the encryption added in #142 with a few simplifications:

1. We don't need the backup key to decrypt. This meant I could simplify the keyring builder
2. This doesn't use the check value as part of the encryption context validation. I will add this later

### Why did it change

We need to decrypt the user's history before we try to insert the new event. It made sense to do it in this Lambda since it's already making the query to DynamoDB - this lets us keep the format Lambda 'permissionless'. 

### Related links

#142 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] Added parameters to Cloudformation template
- [x] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

I am working on a test checklist to verify this in dev