### PR TITLE
add generator key and wrapper key IDs to SSM

### DIFF
--- a/docs/manual-testing/manual-testing.md
+++ b/docs/manual-testing/manual-testing.md
@@ -9,6 +9,6 @@ Instead, the lambdas to query, format and write an activity record are triggered
 
 To insert a new event into the DB:
 
-`gds aws di-account-dev -- aws dynamodb put-item --table-name dummy_events --region eu-west-2 --item file:////./docs/manual-testing/dummy-activity-event.json`
+`gds aws di-account-dev -- aws dynamodb put-item --table-name dummy_events --region eu-west-2 --item file://./docs/manual-testing/dummy-activity-event.json`
 
 Timestamp, client_id, user.user_id, and session_id are the fields you are likely going to want to customise in dummy_activity_event.json.

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2353,6 +2353,14 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}-WrapperKey"
       TargetKeyId: !GetAtt WrapperKey.Arn
 
+  WrapperKeyIDSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the encryption wrapper key
+      Name: !Sub "/${AWS::StackName}/KMS/WrapperKey/ID"
+      Type: String
+      Value: !Ref WrapperKey
+
   GeneratorKey:
     Type: AWS::KMS::Key
     Properties:
@@ -2388,6 +2396,14 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}-GeneratorKey"
       TargetKeyId: !GetAtt GeneratorKey.Arn
+
+  GeneratorKeyIDSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the encryption generator key
+      Name: !Sub "/${AWS::StackName}/KMS/GeneratorKey/ID"
+      Type: String
+      Value: !Ref GeneratorKey
 
   StorageVerificationSecret:
     Type: AWS::SecretsManager::Secret

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1403,6 +1403,8 @@ Resources:
           OUTPUT_QUEUE_URL: !Ref ActivityLogToFormatQueue
           ENVIRONMENT: !Ref Environment
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
+          GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
+          WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA


### PR DESCRIPTION
## Proposed changes

[OLH-1014] - decrypt activity log in front end 


### What changed

separate commits:
- Add generator key and wrapper key IDs to SSM
- Correct manual testing file path
- Add key arns as environment variables on query-activity-log lambda 

### Why did it change

Add key arns as environment variables to enable decryption. 
Add generator key and wrapper key IDs to SSM in order to make the 

### Related links



## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[OLH-1014]: https://govukverify.atlassian.net/browse/OLH-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ