### PR TITLE
OLH-904: Fix decrypt lambda

### DIFF
--- a/docs/manual-testing/manual-testing.md
+++ b/docs/manual-testing/manual-testing.md
@@ -9,6 +9,6 @@ Instead, the lambdas to query, format and write an activity record are triggered
 
 To insert a new event into the DB:
 
-`gds aws di-account-dev -- aws dynamodb put-item --table-name dummy_events --region eu-west-2 --item file:////./docs/manual-testing/dummy-activity-event.json`
+`gds aws di-account-dev -- aws dynamodb put-item --table-name dummy_events --region eu-west-2 --item file://./docs/manual-testing/dummy-activity-event.json`
 
 Timestamp, client_id, user.user_id, and session_id are the fields you are likely going to want to customise in dummy_activity_event.json.

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1403,8 +1403,6 @@ Resources:
           OUTPUT_QUEUE_URL: !Ref ActivityLogToFormatQueue
           ENVIRONMENT: !Ref Environment
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
-          GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
-          WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
@@ -1489,6 +1487,12 @@ Resources:
             Resource:
               - !GetAtt QueueKmsKey.Arn
               - !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              - !GetAtt WrapperKey.Arn
+              - !GetAtt GeneratorKey.Arn
 
   QueryActivityLogDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -2355,14 +2359,6 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}-WrapperKey"
       TargetKeyId: !GetAtt WrapperKey.Arn
 
-  WrapperKeyIDSSMParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The ID of the encryption wrapper key
-      Name: !Sub "/${AWS::StackName}/KMS/WrapperKey/ID"
-      Type: String
-      Value: !Ref WrapperKey
-
   GeneratorKey:
     Type: AWS::KMS::Key
     Properties:
@@ -2398,14 +2394,6 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}-GeneratorKey"
       TargetKeyId: !GetAtt GeneratorKey.Arn
-
-  GeneratorKeyIDSSMParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: The ID of the encryption generator key
-      Name: !Sub "/${AWS::StackName}/KMS/GeneratorKey/ID"
-      Type: String
-      Value: !Ref GeneratorKey
 
   StorageVerificationSecret:
     Type: AWS::SecretsManager::Secret

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2353,6 +2353,14 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}-WrapperKey"
       TargetKeyId: !GetAtt WrapperKey.Arn
 
+  WrapperKeyIDSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the encryption wrapper key
+      Name: !Sub "/${AWS::StackName}/KMS/WrapperKey/ID"
+      Type: String
+      Value: !Ref WrapperKey
+
   GeneratorKey:
     Type: AWS::KMS::Key
     Properties:
@@ -2388,6 +2396,14 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}-GeneratorKey"
       TargetKeyId: !GetAtt GeneratorKey.Arn
+
+  GeneratorKeyIDSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ID of the encryption generator key
+      Name: !Sub "/${AWS::StackName}/KMS/GeneratorKey/ID"
+      Type: String
+      Value: !Ref GeneratorKey
 
   StorageVerificationSecret:
     Type: AWS::SecretsManager::Secret

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1403,6 +1403,8 @@ Resources:
           OUTPUT_QUEUE_URL: !Ref ActivityLogToFormatQueue
           ENVIRONMENT: !Ref Environment
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
+          GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
+          WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA

--- a/lambda/query-activity-log/decrypt-data.ts
+++ b/lambda/query-activity-log/decrypt-data.ts
@@ -7,6 +7,7 @@ import buildKmsKeyring from "./kms-keyring-builder";
 
 const MAX_ENCRYPTED_DATA_KEY = 5;
 const DECODING = "utf8";
+const ENCODING = "base64";
 
 const decryptClientConfig = { maxEncryptedDataKeys: MAX_ENCRYPTED_DATA_KEY };
 const decryptClient = buildDecrypt(decryptClientConfig);
@@ -56,7 +57,10 @@ export async function decryptData(
 ): Promise<string> {
   try {
     keyring ??= await buildKmsKeyring();
-    const result = await decryptClient.decrypt(keyring, data);
+    const result = await decryptClient.decrypt(
+      keyring,
+      Buffer.from(data, ENCODING)
+    );
     validateEncryptionContext(
       result.messageHeader.encryptionContext,
       generateExpectedContext(userId)

--- a/lambda/query-activity-log/tests/decrypt-data.test.ts
+++ b/lambda/query-activity-log/tests/decrypt-data.test.ts
@@ -139,7 +139,7 @@ describe("decryptActivities", () => {
         generatorKeyId:
           "arn:aws:kms:eu-west-2:111122223333:key/bc436485-5092-42b8-92a3-0aa8b93536dc",
       },
-      encryptedActivities
+      Buffer.from(encryptedActivities, "base64")
     );
   });
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Add KMS permissions, the key ARN environment variables and decode the base64 string back into bytes.

### Why did it change

This fixes the `query-activity-log` lambda for users who already have stored data.

### Related links

#143 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [x] Added new environment variable

### Permissions

- [x] This PR adds or changes permissions

## Testing

I've deployed this branch to dev and sent some events to the dummy event store. You can see the successful invocations in [Cloudwatch](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fdev-account-mgmt-backend-query-activity-log/log-events/2023$252F09$252F27$252F$255B$2524LATEST$255D60dae1a6bd4f4ef6885f6ad8f43d7fa5)

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
