### PR TITLE
OLH-1118: Set up queues and key for audit events

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -135,6 +135,18 @@ Mappings:
     production:
       AccountNumber: "499563136613"
 
+  TxmaAccounts:
+    dev:
+      AccountNumber: "248098332657"
+    build:
+      AccountNumber: "750703655225"
+    staging:
+      AccountNumber: "178023842775"
+    integration:
+      AccountNumber: "729485541398"
+    production:
+      AccountNumber: "451773080033"
+
 Resources:
   ######################################
   # Dummy events store
@@ -309,6 +321,76 @@ Resources:
       KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
+
+  ########################################
+  # Output queue for audit events to TxMA
+  ########################################
+
+  AuditOutputQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref AuditEncryptionKey
+      MessageRetentionPeriod: 1209600
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt AuditDeadLetterQueue.Arn
+        maxReceiveCount: 5
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  AuditOutputQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref AuditOutputQueue
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap [TxmaAccounts, !Ref Environment, AccountNumber]
+            Action:
+              - sqs:ChangeMessageVisibility
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:ReceiveMessage
+            Resource: !GetAtt AuditOutputQueue.Arn
+
+  AuditDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref AuditEncryptionKey
+      MessageRetentionPeriod: 1209600
+      RedriveAllowPolicy:
+        redrivePermission: allowAll
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  AuditEncryptionKey:
+    Type: AWS::KMS::Key
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource:
+              - "*"
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap [TxmaAccounts, !Ref Environment, AccountNumber]
+            Action: kms:Decrypt
+            Resource:
+              - "*"
+
+  AuditEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}/${Environment}/AuditEncryptionKey"
+      TargetKeyId: !Ref AuditEncryptionKey
 
   ######################
   # Save Raw Events


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Following the guidance from TxMA[^1], this sets up an SQS queue that we'll send audit events to, a KMS key to encrypt the events at rest and a dead letter queue.

This uses the 14 day message retention policy recommended by TxMA.

The permissions here allow any resource from TxMA's accounts to consume messages from the queue and decrypt them with the KMS key. The account IDs come from TxMA's documentation[^2].

Right now nothing in our account has permission to write to the queue - we'll add these once we start working on producing events.

### Why did it change

We're setting up as a new audit event producer since we need to generate events when a user takes action on the triage page. The first step in this process is to create these new resource, add them to the list of producers on Confluence and let TxMA know about them.

### Related links

[^1]: https://govukverify.atlassian.net/wiki/spaces/TMA/pages/3603661028/2.+How+to+provision+the+infrastructure+on+your+end+and+understand+what+work+needs+to+happen+between+TxMA+and+your+team
[^2]: https://govukverify.atlassian.net/wiki/spaces/TMA/pages/3135733785/Account+Details

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [x] This PR adds or changes permissions

## Testing

I've [deployed this to dev](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/985326104449/projects/Deploy-account-mgmt-backend-pipeline/build/Deploy-account-mgmt-backend-pipeline%3A425cd41c-ce15-44a5-9de5-00f00632f6e0/?region=eu-west-2) to make sure it's valid Cloudformation. 

## How to review

Please verify the TxMA account IDs against the documentation. They should be from the event processing accounts.
