### PR TITLE
OLH-1174: Export audit queue parameters

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -392,6 +392,30 @@ Resources:
       AliasName: !Sub "alias/${AWS::StackName}/${Environment}/AuditEncryptionKey"
       TargetKeyId: !Ref AuditEncryptionKey
 
+  AuditQueueArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the audit event output queue
+      Name: !Sub "/${AWS::StackName}/SQS/AuditQueue/ARN"
+      Type: String
+      Value: !GetAtt AuditOutputQueue.Arn
+
+  AuditQueueUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The URL of the audit event output queue
+      Name: !Sub "/${AWS::StackName}/SQS/AuditQueue/URL"
+      Type: String
+      Value: !Ref AuditOutputQueue
+
+  AuditQueueKeyArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: The ARN of the KMS key encrypting the audit event output queue
+      Name: !Sub "/${AWS::StackName}/KMS/AuditQueueKey/ARN"
+      Type: String
+      Value: !GetAtt AuditEncryptionKey.Arn
+
   ######################
   # Save Raw Events
   ######################


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Export the audit queue URL, ARN and key ARN as parameters to SSM.

### Why did it change

We need to reference these from the frontend stack in order to pass the queue URL as an environment variable and give the ECS role permissions to write to the queue.

Export them as SSM parameters so we can import them into the other stack

### Related links

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] Added parameters to Cloudformation template
- [x] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

I've [deployed to dev](https://eu-west-2.console.aws.amazon.com/systems-manager/parameters/account-mgmt-backend/SQS/AuditQueue/URL/description?region=eu-west-2&tab=Table#list_parameter_filters=Name:Contains:audit) and checked the params have values. 

