### PR TITLE
OLH-1190: Don't export logs to Splunk in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build.toml
 .idea
 .DS_Store
+.vscode/

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -68,6 +68,12 @@ Conditions:
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
 
+  ExportLogsToSplunk:
+    Fn::Or:
+      - !Equals [!Ref Environment, staging]
+      - !Equals [!Ref Environment, integration]
+      - !Equals [!Ref Environment, production]
+
 Globals:
   Function:
     CodeSigningConfigArn: !If
@@ -543,7 +549,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   SaveRawEventsCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -714,7 +720,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   QueryUserServicesCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -860,7 +866,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   FormatUserServicesCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1013,7 +1019,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   WriteUserServicesCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1216,7 +1222,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   DeleteUserServicesCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1455,7 +1461,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   DeleteEmailSubscriptionsCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1618,7 +1624,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   QueryActivityLogCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1793,7 +1799,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   WriteActivityLogCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -1936,7 +1942,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   FormatActivityLogCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
@@ -2146,7 +2152,7 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   DeleteActivityLogCSLSSubscription:
-    Condition: IsNotDevelopment
+    Condition: ExportLogsToSplunk
     Type: AWS::Logs::SubscriptionFilter
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"


### PR DESCRIPTION
## Proposed changes

### What changed

Set up a new [condition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html) to track which environments we want to send logs to Splunk via the CSLS, and apply it to all the lambda log groups. This condition is only true in staging, integration and production, so now we won't send logs to Splunk in our dev or build environments.

Also update the `.gitignore` file so I don't commit the VS code cache folder.

### Why did it change

We run our performance (load) tests in build and these generate several GB of logs each run. We share the daily Splunk ingest quota with all of Cabinet Office and we're regularly hitting that quota which means we've been asked to stop sending logs to Splunk when we run performance tests.

It's much simpler to simply not send logs to Splunk in build at all. If we need to look at application logs for any reason we still have them in Cloudwatch, or we can try to replicate an issue in a higher environment where we do export the logs.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

Please check my condition logic is correct - it needs to be true in production!