### PR TITLE
OLH-1213 Add Dynatrace layer to backend lambdas

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -98,6 +98,37 @@ Conditions:
 
 Globals:
   Function:
+    Environment:
+      Variables:
+        AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
+        DT_CONNECTION_AUTH_TOKEN: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_CONNECTION_BASE_URL: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_CLUSTER_ID: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_TENANT: !Sub
+          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
+          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
+    Architectures: ["arm64"]
+    MemorySize: 128
+    KmsKeyArn: !GetAtt LambdaKMSKey.Arn
+    ReservedConcurrentExecutions: 10
+    Runtime: nodejs18.x
+    Timeout: 5
+    VpcConfig:
+      SubnetIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
+      SecurityGroupIds:
+        - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     CodeSigningConfigArn: !If
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
@@ -106,6 +137,10 @@ Globals:
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
+    Layers:
+      - !Sub
+        - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
+        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
 
 Mappings:
   InputQueue:
@@ -174,6 +209,19 @@ Mappings:
       AccountNumber: "729485541398"
     production:
       AccountNumber: "451773080033"
+
+  EnvironmentConfiguration:
+    dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    build:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    staging:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    integration:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    production:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+
 
 Resources:
   ######################################
@@ -453,8 +501,8 @@ Resources:
       - SaveRawEventsFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-save-raw-events
-      Architectures: ["arm64"]
       CodeUri: ../lambda/save-raw-events/
+      PackageType: Zip
       Events:
         InputQueue:
           Type: SQS
@@ -467,23 +515,11 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt SaveRawEventsDeadLetterQueue.Arn
       Handler: save-raw-events.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt SaveRawEventsRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref RawEventsStoreTableName
           DLQ_URL: !Ref SaveRawEventsDeadLetterQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -609,8 +645,8 @@ Resources:
       - QueryUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-query-user-services
-      Architectures: ["arm64"]
       CodeUri: ../lambda/query-user-services/
+      PackageType: Zip
       Events:
         DynamoStream:
           Type: DynamoDB
@@ -629,24 +665,12 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt QueryUserServicesDeadLetterQueue.Arn
       Handler: query-user-services.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt QueryUserServicesRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref QueryUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToFormatQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -787,8 +811,8 @@ Resources:
       - FormatUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-format-user-services
-      Architectures: ["arm64"]
       CodeUri: ../lambda/format-user-services/
+      PackageType: Zip
       Events:
         UserServicesToFormatQueue:
           Type: SQS
@@ -798,23 +822,11 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt FormatUserServicesDeadLetterQueue.Arn
       Handler: format-user-services.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt FormatUserServicesRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           DLQ_URL: !Ref FormatUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -933,8 +945,8 @@ Resources:
       - WriteUserServicesFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-write-user-services
-      Architectures: ["arm64"]
       CodeUri: ../lambda/write-user-services/
+      PackageType: Zip
       Events:
         UserServicesToWriteQueue:
           Type: SQS
@@ -944,23 +956,11 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
       Handler: write-user-services.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt WriteServiceRecordRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref WriteUserServicesDeadLetterQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1158,29 +1158,17 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-user-services
-      Architectures: ["arm64"]
       CodeUri: ../lambda/delete-user-services/
+      PackageType: Zip
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt DeleteUserServicesDeadLetterQueue.Arn
       Handler: delete-user-services.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt DeleteUserServicesRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref DeleteUserServicesDeadLetterQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1384,14 +1372,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-email-subscriptions
-      Architectures: ["arm64"]
-      ReservedConcurrentExecutions: 10
       CodeUri: ../lambda/delete-email-subscriptions/
-      Handler: delete-email-subscriptions.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
-      Runtime: nodejs18.x
+      Handler: delete-email-subscriptions.handler
       Role: !GetAtt DeleteEmailSubscriptionsRole.Arn
       Timeout: 30
       EventInvokeConfig:
@@ -1413,12 +1396,6 @@ Resources:
               !Ref Environment,
               GOVACCOUNTSPUBLISHINGAPIURL,
             ]
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1501,14 +1478,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-query-activity-log
-      Architectures: ["arm64"]
-      ReservedConcurrentExecutions: 10
       CodeUri: ../lambda/query-activity-log/
-      Handler: query-activity-log.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
-      Runtime: nodejs18.x
+      Handler: query-activity-log.handler
       Role: !GetAtt QueryActivityLogLambdaRole.Arn
       Timeout: 30
       EventInvokeConfig:
@@ -1546,12 +1518,6 @@ Resources:
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1710,8 +1676,8 @@ Resources:
       - WriteActivityLogFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-write-activity-log
-      Architectures: ["arm64"]
       CodeUri: ../lambda/write-activity-log/
+      PackageType: Zip
       Events:
         ActivityLogToWriteQueue:
           Type: SQS
@@ -1721,13 +1687,7 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt WriteActivityRecordRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogStoreTableName
@@ -1738,12 +1698,6 @@ Resources:
           VERIFY_ACCESS_VALUE: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Storage/VerificationSecret}}"
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           ENVIRONMENT: !Ref Environment
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1877,8 +1831,8 @@ Resources:
       - FormatActivityLogFunctionLogGroup
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-format-activity-log
-      Architectures: ["arm64"]
       CodeUri: ../lambda/format-activity-log/
+      PackageType: Zip
       Events:
         ActivityLogToFormatQueue:
           Type: SQS
@@ -1888,23 +1842,11 @@ Resources:
         Type: SQS
         TargetArn: !GetAtt FormatActivityLogDeadLetterQueue.Arn
       Handler: format-activity-log.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt FormatActivityLogRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           DLQ_URL: !Ref FormatActivityLogDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref ActivityLogToWriteQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2086,29 +2028,17 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-activity-log
-      Architectures: ["arm64"]
       CodeUri: ../lambda/delete-activity-log/
+      PackageType: Zip
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt DeleteActivityLogDeadLetterQueue.Arn
       Handler: delete-activity-log.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
-      PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt DeleteActivityLogRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogStoreTableName
           DLQ_URL: !Ref DeleteActivityLogDeadLetterQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
Add Dynatrace to backend resources.

### What changed

<!-- Describe the changes in detail - the "what"-->
Updated template as per Observability teams documentation.
Moved common values to Globals and switched to using the public VPC subnets.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To allow metrics to be shipped to Dynatrace.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Data can be seen in Dynatrace for the dev environment.

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
When deployed in dev data from interactions with the Account Home page can be seen in Dynatrace.

The process to add Dynatrace is documented in this README https://github.com/govuk-one-login/observability-infrastructure/tree/main/fargate.
You also need to know about this https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3809542559/Dynatrace+VPC+Endpoint page which is not mentioned in the README.
