### PR TITLE
OLH-857 - Turn on the flow of activity log data from TxMA in lower environments up to staging

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -74,6 +74,12 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
+  StoreActivityLogData:
+    Fn::Or:
+      - !Equals [!Ref Environment, build]
+      - !Equals [!Ref Environment, dev]
+      - !Equals [!Ref Environment, staging]
+
 Globals:
   Function:
     CodeSigningConfigArn: !If
@@ -1496,7 +1502,10 @@ Resources:
           Type: DynamoDB
           Properties:
             BatchSize: 1
-            Stream: !GetAtt DummyEventStore.StreamArn
+            Stream: !If
+                - StoreActivityLogData
+                - !GetAtt RawEventsStore.StreamArn
+                - !GetAtt DummyEventStore.StreamArn
             Enabled: true
             DestinationConfig:
               OnFailure:
@@ -1589,10 +1598,18 @@ Resources:
               - dynamodb:GetShardIterator
               - dynamodb:ListStreams
             Resource:
-              - !GetAtt DummyEventStore.StreamArn
-              - !Sub
-                - "${Arn}/*"
-                - Arn: !GetAtt DummyEventStore.StreamArn
+            - !If
+                - StoreActivityLogData
+                - !GetAtt RawEventsStore.StreamArn
+                - !GetAtt DummyEventStore.StreamArn
+            - !If
+                - StoreActivityLogData
+                - !Sub
+                  - "${Arn}/*"
+                  - Arn: !GetAtt RawEventsStore.StreamArn
+                - !Sub
+                  - "${Arn}/*"
+                  - Arn: !GetAtt DummyEventStore.StreamArn
           - Effect: Allow
             Action:
               - kms:Decrypt


### PR DESCRIPTION
## Proposed changes
Turn on the flow of activity log data from TxMA in lower environments up to staging
OLH-857 - Turn on the flow of activity log data from TxMA to the activity log store in staging


### What changed

Created a new Condition in the backend sam template that’s true if the environment should store activity log data. 

Switch the DynamoDB stream the query-activity-logs lambda uses from the dummy events table to the real raw events table 

### Why did it change

So we can start collecting data for users' activity history and test the system end-to-end

### Related links


## Checklists

### Environment variables or secrets

- [x] Added new condition to SAM template
- [x] Used condition in the Query Activity Log Lambda Function Definition to determine which EventStore to read from

### Permissions

## Testing
1. Deploy to dev
2.  Insert a new valid TxMA event in the raw event store
3. Verify message was picked up and sent to the ActivityLogToFormatQueue

## How to review