### PR TITLE
OLH-1242: Set up SNS topic for reporting suspicious activity

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1058,6 +1058,13 @@ Resources:
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: UserAccountDeletion
 
+  ReportSuspiciousActivityTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: ReportSuspiciousActivityTopic
+      KmsMasterKeyId: !Ref SnsKmsKey
+      TopicName: ReportSuspiciousActivity
+
   UserAccountDeletionTopicPolicy:
     Condition: IsNotDevelopment
     Type: AWS::SNS::TopicPolicy

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1058,13 +1058,6 @@ Resources:
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: UserAccountDeletion
 
-  ReportSuspiciousActivityTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      DisplayName: ReportSuspiciousActivityTopic
-      KmsMasterKeyId: !Ref SnsKmsKey
-      TopicName: ReportSuspiciousActivity
-
   UserAccountDeletionTopicPolicy:
     Condition: IsNotDevelopment
     Type: AWS::SNS::TopicPolicy
@@ -2565,3 +2558,18 @@ Resources:
       Name: !Sub "/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN"
       Type: String
       Value: "please-set-me"
+
+  SuspiciousActivityTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: SuspiciousActivityTopic
+      KmsMasterKeyId: !Ref SnsKmsKey
+      TopicName: SuspiciousActivity
+
+  SuspiciousActivityTopicArnSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: SuspiciousActivityTopicARN
+      Description: ARN of the SNS topic for reporting suspicious activity
+      SecretString:
+        !Ref SuspiciousActivityTopic

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2566,10 +2566,10 @@ Resources:
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: SuspiciousActivity
 
-  SuspiciousActivityTopicArnSecret:
+  SuspiciousActivityTopicSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: SuspiciousActivityTopicARN
+      Name: !Sub "/${AWS::StackName}/Config/Storage/SuspiciousActivityTopicSecret"
       Description: ARN of the SNS topic for reporting suspicious activity
       SecretString:
         !Ref SuspiciousActivityTopic

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2566,10 +2566,10 @@ Resources:
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: SuspiciousActivity
 
-  SuspiciousActivityTopicSecret:
-    Type: AWS::SecretsManager::Secret
+  SuspiciousActivityArnParameter:
+    Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/${AWS::StackName}/Config/Storage/SuspiciousActivityTopicSecret"
-      Description: ARN of the SNS topic for reporting suspicious activity
-      SecretString:
-        !Ref SuspiciousActivityTopic
+      Description: The ARN of the Suspicious Activity Topic
+      Name: !Sub "/${AWS::StackName}/SNS/SuspiciousActivity/ARN"
+      Type: String
+      Value: !Ref SuspiciousActivityTopic

--- a/lambda/write-activity-log/tests/encrypt-data.test.ts
+++ b/lambda/write-activity-log/tests/encrypt-data.test.ts
@@ -22,7 +22,11 @@ jest.mock("@aws-crypto/client-node", () => ({
 }));
 
 describe("encryptData", () => {
-  let encryptDataInput: any;
+  let encryptDataInput: {
+    activityLogData: string;
+    userId: string;
+    jwt: string;
+  };
 
   beforeEach(() => {
     const activityLogEntry = JSON.stringify(TEST_ACTIVITY_LOG_ENTRY);
@@ -30,6 +34,7 @@ describe("encryptData", () => {
     encryptDataInput = {
       activityLogData: activityLogEntry,
       userId: "test_user_123",
+      jwt: "",
     };
 
     process.env.GENERATOR_KEY_ARN =


### PR DESCRIPTION
## Proposed changes

Set up a new SNS topic for the ‘report suspicious activity' messages in the backend template and store the topic ARN in a new secrets manager parameter.

### What changed

Added section in the template to create both resources

