### PR TITLE
OLH-1217 Send VPC logs to Splunk

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2558,3 +2558,12 @@ Resources:
       Name: !Sub "/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN"
       Type: String
       Value: "please-set-me"
+
+  VPCFlowLogsSplunkSubscription:
+    Condition: ExportLogsToSplunk
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Sub "${AWS::StackName}-FlowLogLogGroup"
+


### PR DESCRIPTION
## Proposed changes

The latest version of the VPC stack stores VPC flow logs in Cloudwatch. Our security monitoring team needs these logs forwarded to Splunk so they can monitor the VPC.

### What changed

Section added to template.yml

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

https://github.com/govuk-one-login/devplatform-deploy/pull/1318

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
