### PR TITLE
OLH-1217: Import VPC flow log group name

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2646,8 +2646,9 @@ Resources:
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
       FilterPattern: ""
-      LogGroupName: !Sub "${AWS::StackName}-FlowLogLogGroup"
-
+      LogGroupName:
+        Fn::ImportValue:
+          Fn::Sub: "${VpcStackName}-FlowLogLogGroup"
 
   SuspiciousActivityTopic:
     Type: AWS::SNS::Topic

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1054,7 +1054,11 @@ Resources:
       AlarmName:
         !Join [
           "-",
-          [!Ref AWS::StackName, !Ref Environment, WriteUserServicesDeadLetterQueueAlarm],
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            WriteUserServicesDeadLetterQueueAlarm,
+          ],
         ]
       Namespace: "AWS/SQS"
       MetricName: "ApproximateNumberOfMessagesVisible"
@@ -1519,9 +1523,9 @@ Resources:
           Properties:
             BatchSize: 1
             Stream: !If
-                - StoreActivityLogData
-                - !GetAtt RawEventsStore.StreamArn
-                - !GetAtt DummyEventStore.StreamArn
+              - StoreActivityLogData
+              - !GetAtt RawEventsStore.StreamArn
+              - !GetAtt DummyEventStore.StreamArn
             Enabled: true
             DestinationConfig:
               OnFailure:
@@ -1614,11 +1618,11 @@ Resources:
               - dynamodb:GetShardIterator
               - dynamodb:ListStreams
             Resource:
-            - !If
+              - !If
                 - StoreActivityLogData
                 - !GetAtt RawEventsStore.StreamArn
                 - !GetAtt DummyEventStore.StreamArn
-            - !If
+              - !If
                 - StoreActivityLogData
                 - !Sub
                   - "${Arn}/*"


### PR DESCRIPTION

## Proposed changes

### What changed

Import VPC flow log group name from the VPC stack outputs.

### Why did it change

We need to import this - the group is created by the VPC stack and doesn't have a fixed name because Cloudformation adds the pseudorandom stack ID to the end of all resources created by the stack. This means that the step to create the log subscription fails because the log group it's referring to doesn't exist.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

We'll only see if this works once it's deployed to staging because that's where we're seeing the error at the moment.
