### PR TITLE
INCIDEN-569 - Not able to create SubscriptionFilters to CSLS, blocking deployments

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2406,14 +2406,6 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
-  SendSuspiciousActivityToTxMACSLSSubscription:
-    Condition: ExportLogsToSplunk
-    Type: AWS::Logs::SubscriptionFilter
-    Properties:
-      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
-      FilterPattern: ""
-      LogGroupName: !Ref SendSuspiciousActivityToTxMAFunctionLogGroup
-
   #######################
   # Monitoring
   #######################


### PR DESCRIPTION
## Proposed changes
https://govukverify.atlassian.net/browse/INCIDEN-569

### What changed

Removed the recent subscription filter (`SendSuspiciousActivityToTxMACSLSSubscription`), we opted for removing, rather than leaving and commenting out. We will add back once the issue is resolved.


### Why did it change
We currently cannot add new subscription filter, this will cause a permission error in higher environments.

### Related links
More info here: https://govukverify.atlassian.net/browse/INCIDEN-569

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

## Testing

Once merged, follow the environment build | staging | prod and ensure deployment succeeds. 
We should stop seeing a deployment error of
`Resource handler returned message: "User with accountId: 539729775994 is not authorized to perform PutSubscriptionFilter on resources arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython.`

## How to review