### PR TITLE
OLH-1285: Update VPC flow log group name

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2737,7 +2737,9 @@ Resources:
     Properties:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
       FilterPattern: ""
-      LogGroupName: !Sub "${AWS::StackName}-FlowLogLogGroup"
+      LogGroupName:
+        Fn::ImportValue:
+          Fn::Sub: "${VpcStackName}-FlowLogLogGroup"
 
 
   SuspiciousActivityTopic:


### PR DESCRIPTION
### What changed

Import VPC flow log group name from the VPC stack outputs.

### Why did it change

We need to import this - the group is created by the VPC stack and doesn't have a fixed name because CloudFormation adds the pseudorandom stack ID to the end of all resources created by the stack. This means that the step to create the log subscription fails because the log group it's referring to doesn't exist.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

We'll only see if this works once it's deployed to staging because that's where we're seeing the error at the moment.
